### PR TITLE
docs(ux): add UX specification for web frontend

### DIFF
--- a/docs/adr/ADR-0008-web-ui-branding.md
+++ b/docs/adr/ADR-0008-web-ui-branding.md
@@ -1,0 +1,112 @@
+# ADR-0008: Web UI Deployment-Time Branding
+
+Status: Accepted
+Date: 2026-03-24
+Owners: RepoRoller team
+
+## Context
+
+RepoRoller is an open-source tool that organizations deploy internally as a self-service
+repository creation interface. Organizations want the deployed tool to appear as part of their
+own internal tooling ecosystem — using their logo, company name, and brand colours — rather than
+presenting as a generic "RepoRoller" product.
+
+The requirement is branding, not arbitrary theming. The layout, component structure, interaction
+patterns, and copy are fixed by the UX specification. Only the visual identity markers need to
+be configurable.
+
+Constraints:
+
+- No build step per deployment — changing branding must not require recompiling the SvelteKit
+  application
+- Single mechanism — operators should not need to understand CSS overrides or component internals
+- Accessible by default — any brand colour used must meet WCAG contrast requirements on
+  white/light backgrounds (text and interactive elements); this is the operator's responsibility
+  to verify, but the system must make that verification straightforward
+- Consistent across all screens — branding must apply everywhere, including the unauthenticated
+  auth screens (sign-in, OAuth callback, access denied)
+
+## Decision
+
+Provide **four deployment-time configuration tokens** consumed at SvelteKit server startup:
+
+| Token | Type | Default |
+|---|---|---|
+| `app_name` | string | `"RepoRoller"` |
+| `logo_url` | string \| null | null |
+| `logo_alt` | string | `"[app_name] logo"` |
+| `primary_color` | CSS hex string | `"#0969da"` |
+
+**Configuration source** (priority order, highest first):
+
+1. Environment variables: `BRAND_APP_NAME`, `BRAND_LOGO_URL`, `BRAND_LOGO_ALT`, `BRAND_PRIMARY_COLOR`
+2. `brand.toml` file in the deployment working directory
+3. Built-in defaults
+
+**Colour propagation**: `primary_color` is written as a CSS custom property on the root `<html>`
+element at server-render time:
+
+```html
+<html style="--brand-primary: #d4451a;">
+```
+
+All interactive elements (buttons, selected card borders, step indicators, links, focus rings)
+reference `var(--brand-primary)` rather than hardcoded colour values. A single config change
+recolours the entire application.
+
+**Logo fallback**: When `logo_url` is null, the `app_name` string is rendered as a styled text
+wordmark. The layout reserves a fixed height for the logo area in all cases, preventing layout
+shift between deployments.
+
+**App name propagation**: `app_name` is made available to all SvelteKit pages via the root
+layout `load` function. Page `<title>` elements and `<h1>` headings that include the app name
+read from this value, not from a hardcoded string.
+
+## Consequences
+
+**Enables:**
+
+- Organizations deploy RepoRoller under their own visual identity with no code changes
+- A single environment variable change at deploy time is sufficient for colour customisation
+- The fallback chain (env vars → file → defaults) supports both containerised and traditional
+  deployments
+- Adding a fifth token (e.g., `favicon_url`) in future requires no architectural changes
+
+**Forbids:**
+
+- Per-user or per-session branding (configuration is deployment-time only)
+- Changing layout, component structure, or interaction patterns through branding config
+- Arbitrary CSS injection via the branding config (only the four tokens are supported)
+
+**Trade-offs:**
+
+- The operator is responsible for ensuring their chosen `primary_color` meets WCAG AA contrast
+  requirements (4.5:1 for normal text, 3:1 for large text and UI components) — the system does
+  not validate this
+- Server-side rendering means the CSS custom property is always set before first paint; there is
+  no flash of default colour
+
+## Alternatives considered
+
+### Option A: CSS override file
+
+Let operators provide a full `custom.css` file mounted into the deployment.
+
+**Why not**: Requires detailed knowledge of the component structure and CSS class names. Brittle
+across upgrades. Cannot be expressed as environment variables for container deployments. More
+surface area for unintended visual breakage.
+
+### Option B: Build-time configuration (environment variables baked in at `npm run build`)
+
+Bake brand values into the static bundle at build time.
+
+**Why not**: Requires a build pipeline per operator. Builds are not fast. Operators without
+Node.js tooling cannot deploy. Defeats the goal of a simple deployment story.
+
+### Option C: Runtime API endpoint for branding
+
+Serve branding values from a `/api/v1/brand` endpoint and apply them client-side after load.
+
+**Why not**: Causes a visible flash of default colours before the brand CSS applies. Adds an
+extra round-trip before the page is visually stable. More complex than reading config at
+server startup.

--- a/docs/adr/ADR-008-web-ui-branding.md
+++ b/docs/adr/ADR-008-web-ui-branding.md
@@ -1,4 +1,4 @@
-# ADR-0008: Web UI Deployment-Time Branding
+# ADR-008: Web UI Deployment-Time Branding
 
 Status: Accepted
 Date: 2026-03-24

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,7 +31,7 @@ Write an ADR for decisions that:
 - [ADR-005: Multiple User Interface Strategy](ADR-005-multiple-user-interfaces.md) - CLI, API, MCP, and Azure Functions sharing single business logic core
 - [ADR-006: GitHub App Authentication](ADR-006-github-app-authentication.md) - Installation tokens for organization-scoped, auto-rotating authentication
 - [ADR-007: Repository Rulesets for Branch Protection](ADR-007-repository-rulesets.md) - Additive ruleset composition for flexible repository protection
-- [ADR-0008: Web UI Deployment-Time Branding](ADR-0008-web-ui-branding.md) - Four-token branding config (logo, name, colour) via env vars or brand.toml
+- [ADR-008: Web UI Deployment-Time Branding](ADR-008-web-ui-branding.md) - Four-token branding config (logo, name, colour) via env vars or brand.toml
 
 ## Related Documentation
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ Write an ADR for decisions that:
 - [ADR-005: Multiple User Interface Strategy](ADR-005-multiple-user-interfaces.md) - CLI, API, MCP, and Azure Functions sharing single business logic core
 - [ADR-006: GitHub App Authentication](ADR-006-github-app-authentication.md) - Installation tokens for organization-scoped, auto-rotating authentication
 - [ADR-007: Repository Rulesets for Branch Protection](ADR-007-repository-rulesets.md) - Additive ruleset composition for flexible repository protection
+- [ADR-0008: Web UI Deployment-Time Branding](ADR-0008-web-ui-branding.md) - Four-token branding config (logo, name, colour) via env vars or brand.toml
 
 ## Related Documentation
 

--- a/docs/spec/ux/README.md
+++ b/docs/spec/ux/README.md
@@ -1,0 +1,117 @@
+# RepoRoller Web UI — UX Specification
+
+## Overview
+
+The RepoRoller web UI provides a self-service interface for GitHub organization members to create
+new repositories from predefined templates. It is an internal tool, accessible only on the
+organization VPN.
+
+**Primary user goal**: Create a new, fully-configured GitHub repository in minutes, without CLI
+access or manual GitHub setup steps.
+
+**Authentication**: GitHub OAuth (Model A). The VPN handles access control. OAuth captures the
+creator's verified GitHub username for audit logging.
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Auth model | GitHub OAuth ("Sign in with GitHub") | Verified identity for audit trail; VPN is the access gate |
+| Org membership enforcement | Deferred (architecture supports adding later) | VPN is the current boundary; org check can be enabled later |
+| Creation UX | Stepped wizard (2–3 steps) | Template variables are dynamic; sequential steps reduce cognitive overload |
+| Template browsing | Inline as Step 1 of creation wizard | Template browsing is part of the creation decision, not a separate use case |
+| Org selection | None — single org configured at deployment | Removes unnecessary input; multi-org can be added later |
+| Visibility input | Shown only if org configuration permits override | Avoids confusing users with options they cannot change |
+| Branding | Logo, app name, primary colour configured at deployment | Organizations can white-label the tool without code changes; see [branding.md](branding.md) |
+
+---
+
+## Screen Inventory
+
+| ID | Screen | Route | Authentication required |
+|---|---|---|---|
+| SCR-001 | Sign In | `/sign-in` | No |
+| SCR-002 | OAuth Callback | `/auth/callback` | No (in-progress) |
+| SCR-003 | Access Denied | `/auth/denied` | No |
+| SCR-004 | Create Repository | `/create` | Yes |
+| SCR-005 | Repository Created | `/create/success` | Yes |
+| SCR-006 | Error | `/error` | No |
+
+---
+
+## User Flows
+
+- [Authentication flow](flows/authentication.md) — sign-in, OAuth callback, session management
+- [Repository creation flow](flows/repository-creation.md) — template selection through to created repository
+
+---
+
+## Screens
+
+- [SCR-001: Sign In](screens/SCR-001-sign-in.md)
+- [SCR-002: OAuth Callback](screens/SCR-002-oauth-callback.md)
+- [SCR-003: Access Denied](screens/SCR-003-access-denied.md)
+- [SCR-004: Create Repository](screens/SCR-004-create-repository.md)
+- [SCR-005: Repository Created](screens/SCR-005-repository-created.md)
+- [SCR-006: Error](screens/SCR-006-error.md)
+
+---
+
+## Components
+
+- [Component Inventory](components/component-inventory.md)
+
+---
+
+## Supporting Specifications
+
+- [Branding & White-Labelling](branding.md) — deployment-time brand configuration
+- [Navigation Map](navigation.md)
+- [UX Assertions](ux-assertions.md) — testable behaviour specifications
+- [Copy Reference](copy.md) — all user-facing strings in one place
+
+---
+
+## UX Design Complete — Handoff Summary
+
+UX specifications have been produced in `docs/spec/ux/`.
+
+**Screens defined**: 6 (SCR-001 through SCR-006)
+**User flows**: 2 (authentication, repository creation)
+**Components**: 11 reusable components with prop/event contracts + 1 shared shell (BrandCard)
+**UX assertions**: 27 testable behavioural specifications
+**Wireframes**: All 6 screens
+
+### Key design decisions
+
+1. **GitHub OAuth for identity** — VPN is the access gate; OAuth captures a verified GitHub
+   username for the audit log. Org membership check is deferred but the architecture (including
+   `read:org` scope at sign-in time) supports enabling it without re-engineering the auth flow.
+2. **2–3 step wizard** — Step 3 (variables) is conditionally skipped when the selected template
+   defines no variables, keeping the common case to 2 steps.
+3. **Template details fetched on card selection** — eliminates visible loading delay when the
+   user clicks Next to advance from Step 1.
+4. **Name uniqueness check on blur, not on type** — avoids hammering the API on every keystroke.
+5. **Creation errors are inline with data preserved** — users never lose form data on a failed
+   creation attempt; they can correct and retry without starting over.
+6. **Deployment-time branding** — logo, app name, and primary colour are configured via
+   `brand.toml` or environment variables; a CSS custom property (`--brand-primary`) propagates
+   the colour to all interactive elements. See [ADR-0008](../adr/ADR-0008-web-ui-branding.md).
+
+### For the Interface Designer
+
+- Translate component contracts in [components/component-inventory.md](components/component-inventory.md)
+  into typed SvelteKit component props and events.
+- Define a `BrandConfig` type for the branding configuration object (see [branding.md](branding.md)).
+- Define the `NameValidationResult` discriminated union used by `RepositoryNameField` (CMP-006).
+- Define route parameter types for `/create/success?repo={org}/{name}`.
+- Map the `TemplateSummary`, `TemplateVariable`, and `RepositoryTypeOption` shapes from the
+  REST API response types to frontend model types.
+
+### For the Tester
+
+- Use [ux-assertions.md](ux-assertions.md) as the specification for all UI behaviour tests.
+- Priority assertions for initial test coverage: 001, 002, 005, 009, 010, 011, 015, 018, 022.
+- All 27 assertions should eventually have corresponding integration or component tests.

--- a/docs/spec/ux/README.md
+++ b/docs/spec/ux/README.md
@@ -98,7 +98,7 @@ UX specifications have been produced in `docs/spec/ux/`.
    creation attempt; they can correct and retry without starting over.
 6. **Deployment-time branding** — logo, app name, and primary colour are configured via
    `brand.toml` or environment variables; a CSS custom property (`--brand-primary`) propagates
-   the colour to all interactive elements. See [ADR-0008](../adr/ADR-0008-web-ui-branding.md).
+   the colour to all interactive elements. See [ADR-008](../adr/ADR-008-web-ui-branding.md).
 
 ### For the Interface Designer
 

--- a/docs/spec/ux/branding.md
+++ b/docs/spec/ux/branding.md
@@ -49,6 +49,11 @@ logo_alt    = "Acme logo"
 primary_color = "#d4451a"
 ```
 
+> **Security note**: `brand.toml` is a server-side configuration file. It **must not** be placed
+> inside the SvelteKit `static/` (or `public/`) directory — files in that directory are served
+> verbatim to all HTTP clients. Place `brand.toml` in the server's working directory outside the
+> static file serving root, or supply values exclusively via environment variables.
+
 ---
 
 ## How Branding Flows Into the UI

--- a/docs/spec/ux/branding.md
+++ b/docs/spec/ux/branding.md
@@ -1,0 +1,127 @@
+# Branding & White-Labelling
+
+## Overview
+
+The RepoRoller web UI supports deployment-time branding so that organizations can present the
+tool under their own identity. An organization deploying RepoRoller can provide their logo,
+application name, and primary brand colour without modifying source code.
+
+Branding is configuration, not customization. The layout, component structure, and interaction
+patterns are fixed. Only the visual tokens and identity markers are configurable.
+
+---
+
+## What Is Configurable
+
+| Brand element | Config key | Type | Default | Applied to |
+|---|---|---|---|---|
+| Application name | `brand.app_name` | `string` | `"RepoRoller"` | Page titles, headings, sign-in screen |
+| Logo image URL | `brand.logo_url` | `string \| null` | `null` (text wordmark used) | AppShell header, sign-in/callback/access-denied cards |
+| Logo alt text | `brand.logo_alt` | `string` | `"[brand.app_name] logo"` | `alt` attribute of logo `<img>` |
+| Primary colour | `brand.primary_color` | CSS hex string | `"#0969da"` (GitHub blue) | Buttons, selected states, links, progress indicators |
+
+**Intentionally not configurable:**
+
+- Typography (font family, sizes) — fixed for accessible, predictable layout
+- Component structure and layout — white-labelling is not arbitrary theming
+- Error messages and instructional copy — must match the spec to stay accurate
+
+---
+
+## How Branding Is Configured
+
+Branding values are provided at deployment time via a configuration file that the SvelteKit
+server reads at startup. They are **not** user-configurable at runtime and **not** stored in
+the browser.
+
+**Configuration source priority** (highest first):
+
+1. Environment variables: `BRAND_APP_NAME`, `BRAND_LOGO_URL`, `BRAND_LOGO_ALT`, `BRAND_PRIMARY_COLOR`
+2. `brand.toml` file in the deployment directory
+3. Built-in defaults (as listed above)
+
+**Example `brand.toml`:**
+
+```toml
+app_name    = "Acme Dev Tools"
+logo_url    = "/static/acme-logo.svg"
+logo_alt    = "Acme logo"
+primary_color = "#d4451a"
+```
+
+---
+
+## How Branding Flows Into the UI
+
+The SvelteKit server loads branding config once at startup and makes it available to all pages
+via a root layout `load` function. Components that need branding data receive it as props or
+read it from a Svelte context set at the root layout.
+
+The primary colour is injected as a CSS custom property on the root `<html>` element:
+
+```html
+<html style="--brand-primary: #d4451a;">
+```
+
+All interactive elements (buttons, selected cards, focus rings, progress steps, links) reference
+`var(--brand-primary)` rather than a hardcoded colour value. This means the entire colour scheme
+adapts to a single config value with no component-level changes.
+
+---
+
+## Logo Rendering Rules
+
+| Scenario | Rendered as |
+|---|---|
+| `logo_url` is set | `<img src="{logo_url}" alt="{logo_alt}" />` — fixed height, width auto |
+| `logo_url` is null | `<span class="wordmark">{app_name}</span>` — styled text wordmark |
+
+The logo container reserves a fixed height (e.g., 32px in AppShell header, 48px on sign-in card)
+regardless of which variant is rendered, preventing layout shift between deployments.
+
+---
+
+## Impact on Components
+
+### AppShell (CMP-001)
+
+Gains `appName` and `logoUrl` / `logoAlt` props drawn from branding config:
+
+- Header left area: `[logo or wordmark]  [appName]`
+- If `logoUrl` is set: logo image shown; `appName` text is still rendered (visually may be hidden
+  on narrow screens but always present for accessibility)
+
+### Sign In screen (SCR-001)
+
+The sign-in card shows the same logo/wordmark as the AppShell, centred above the heading.
+The `<h1>` reads "Sign in to [appName]".
+
+### OAuth Callback screen (SCR-002) and Access Denied screen (SCR-003)
+
+Same logo/wordmark as the sign-in card, providing visual continuity through the auth flow.
+
+### Page titles
+
+All page `<title>` elements use the pattern `[screen name] — [appName]`.
+When `appName` is "Acme Dev Tools", the sign-in page title becomes "Sign in — Acme Dev Tools".
+
+---
+
+## Accessibility Requirement
+
+When a logo image is used:
+
+- The `alt` attribute must describe the logo meaningfully (e.g., "Acme logo"), not be empty
+- If the `appName` text is visually hidden alongside the logo, it must remain present in the DOM
+  for screen readers (use `class="sr-only"`, not `display: none` or `aria-hidden`)
+
+---
+
+## UX Assertions
+
+Branding assertions are defined in the central assertions file:
+
+- **UX-ASSERT-026** — Logo falls back to text wordmark when `logo_url` is not configured
+- **UX-ASSERT-027** — Custom `primary_color` applies to all interactive elements
+
+See [ux-assertions.md — Branding section](ux-assertions.md#branding).

--- a/docs/spec/ux/components/component-inventory.md
+++ b/docs/spec/ux/components/component-inventory.md
@@ -1,0 +1,375 @@
+# Component Inventory
+
+This document defines the contract for every reusable component in the RepoRoller web UI.
+These contracts are inputs for the Interface Designer to translate into typed SvelteKit component
+props and events.
+
+Components are listed in dependency order (primitives first, composites last).
+
+---
+
+## CMP-001: AppShell
+
+**Used by**: SCR-004, SCR-005, SCR-006 (authenticated variant)
+**Purpose**: Global page layout shell with header containing brand identity and user identity.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `appName` | `string` | Yes | Configured application name (e.g., "Acme Dev Tools"); from branding config |
+| `logoUrl` | `string \| null` | No | Configured logo image URL; if null, `appName` is rendered as a text wordmark |
+| `logoAlt` | `string` | No | Alt text for the logo image; defaults to `"[appName] logo"` |
+| `userLogin` | `string` | Yes | GitHub username of the authenticated user |
+| `userAvatarUrl` | `string \| null` | No | GitHub avatar URL; falls back to initials if null |
+
+### Slots
+
+- `default` — page content below the header
+
+### Events emitted
+
+- `signOut()` — user clicked sign out; caller handles session destruction and navigation
+
+### Header layout
+
+```
+[ logo/wordmark ]  [ appName ]          [ @username ▾ ]
+```
+
+- Logo/wordmark: left-aligned. If `logoUrl` is set, renders `<img>`; otherwise renders styled
+  `appName` text. The `appName` text label is always present in the DOM for screen readers even
+  when a logo image is shown (may be visually hidden on narrow screens using `class="sr-only"`).
+- `appName` text label: shown next to the logo on wider viewports.
+- UserBadge: right-aligned.
+
+### CSS hook
+
+The root `<html>` element has `--brand-primary` set to the configured primary colour.
+All interactive elements in this component (and all other components) reference
+`var(--brand-primary)` for colour values.
+
+### Accessibility
+
+- Header landmark: `<header>` element
+- Main content landmark: `<main>` element wrapping the default slot
+- Logo image: `alt` attribute set to `logoAlt`
+- When logo image is present, adjacent `appName` text uses `aria-hidden="true"` only if the
+  `alt` text already conveys the brand name — otherwise it must remain visible to screen readers
+- Sign-out button has explicit label
+
+---
+
+## CMP-001b: BrandCard
+
+**Used by**: SCR-001, SCR-002, SCR-003
+**Purpose**: Centred card shell for unauthenticated screens (sign-in, OAuth callback, access denied).
+Displays the brand logo/wordmark above the card content, providing visual continuity with the
+AppShell before the user is authenticated.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `appName` | `string` | Yes | Configured application name; from branding config |
+| `logoUrl` | `string \| null` | No | Configured logo image URL; if null, `appName` rendered as text wordmark |
+| `logoAlt` | `string` | No | Alt text for the logo image; defaults to `"[appName] logo"` |
+
+### Slots
+
+- `default` — card body content (heading, message, buttons)
+
+### Layout
+
+```
+          [ logo / wordmark ]
+   ┌──────────────────────────────┐
+   │  (default slot content)      │
+   └──────────────────────────────┘
+```
+
+Logo/wordmark is centred above the card. Card is centred on the viewport both horizontally and
+vertically. No header or footer (intentional — full-screen auth gate).
+
+---
+
+## CMP-002: UserBadge
+
+**Used by**: CMP-001 (AppShell)
+**Purpose**: Display the authenticated user's GitHub avatar and username; provides sign-out trigger.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `login` | `string` | Yes | GitHub username |
+| `avatarUrl` | `string \| null` | No | GitHub avatar URL |
+
+### Events emitted
+
+- `signOut()` — user clicked "Sign out" in the dropdown
+
+### Accessibility
+
+- Avatar image has `alt="[login]'s GitHub avatar"` or `alt=""` if decorative only (when username is also displayed adjacent to it)
+- Dropdown button `aria-haspopup="true"` and `aria-expanded` reflects open state
+- Sign-out option is keyboard accessible
+
+---
+
+## CMP-003: StepProgress
+
+**Used by**: SCR-004 (Create Repository wizard)
+**Purpose**: Visual step progress indicator for the multi-step wizard.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `steps` | `string[]` | Yes | Step labels in order (e.g., `["Choose template", "Settings", "Variables"]`) |
+| `currentStep` | `number` | Yes | 1-indexed current step position |
+
+### Accessibility
+
+- Wrapper has `aria-label="Step [currentStep] of [steps.length]: [currentStepLabel]"`
+- Completed steps indicated visually and with `aria-label` on each step dot
+- Does not steal focus; focus management is handled by the parent wizard
+
+---
+
+## CMP-004: TemplateCard
+
+**Used by**: CMP-005 (TemplateGrid)
+**Purpose**: Selectable card representing a single template.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Template name |
+| `description` | `string` | Yes | Template description (clamped to 2 lines by CSS) |
+| `tags` | `string[]` | No | Tags to display as chips (max 4 displayed) |
+| `repositoryTypeBadge` | `{ typeName: string; policy: 'fixed' \| 'preferable' \| 'optional' } \| null` | No | Repository type badge; null if not applicable |
+| `selected` | `boolean` | Yes | Whether this card is the currently selected template |
+| `loading` | `boolean` | No | Skeleton/placeholder state while template list loads |
+
+### Events emitted
+
+- `select()` — user clicked this card to select it
+
+### States
+
+- **Default**: card with visible content, not selected
+- **Selected**: highlighted border + checkmark icon in top-right corner
+- **Hovered**: subtle lift effect (CSS only, no prop needed)
+- **Loading**: skeleton placeholders; no events
+
+### Accessibility
+
+- Implemented as a `<label>` wrapping a visually-hidden `<input type="radio">` within the
+  template card group; this gives screen readers selection semantics and group context
+- `name` of the radio group: `"template-selection"`
+- `value` of the radio input: template name
+- Card label includes template name and "selected" state for screen readers
+
+---
+
+## CMP-005: TemplateGrid
+
+**Used by**: SCR-004 Step 1
+**Purpose**: Grid of selectable TemplateCards with search filtering and loading/error states.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `templates` | `TemplateSummary[]` | Yes | List of templates from the API |
+| `selectedTemplateName` | `string \| null` | No | Name of currently selected template (controlled) |
+| `loading` | `boolean` | No | Show skeleton cards |
+| `error` | `string \| null` | No | Error message to show instead of cards |
+
+### Events emitted
+
+- `templateSelect(templateName: string)` — user selected a template
+
+### Internal behaviour
+
+- Search bar filters `templates` client-side by matching `name`, `description`, and `tags`
+- When search produces no results: shows "No templates match '[query]'" empty state
+
+### Accessibility
+
+- Search bar: `<input type="search">` with label "Search templates"
+- Radio group wrapping all cards has `role="radiogroup"` and `aria-label="Available templates"`
+- Empty states have `role="status"` (non-urgent announcement)
+
+---
+
+## CMP-006: RepositoryNameField
+
+**Used by**: SCR-004 Step 2
+**Purpose**: Text input for repository name with client-side format validation and async
+uniqueness checking.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `value` | `string` | Yes | Current input value (controlled) |
+| `organization` | `string` | Yes | Org name used in the uniqueness check API call |
+| `disabled` | `boolean` | No | Disables the field (e.g., during creation overlay) |
+
+### Events emitted
+
+- `change(value: string)` — fired on every input change
+- `validationResult(result: NameValidationResult)` — fired after each completed validation cycle
+
+```typescript
+type NameValidationResult =
+  | { status: 'idle' }
+  | { status: 'invalid_format'; message: string }
+  | { status: 'checking' }
+  | { status: 'available' }
+  | { status: 'taken'; name: string }
+  | { status: 'check_failed' };
+```
+
+### Internal behaviour
+
+- On type: debounce 300ms → client-side format check
+- Format regex (client-side): `^[a-z0-9][a-z0-9-]*[a-z0-9]$` or single alphanumeric char
+  (mirrors GitHub naming rules — lowercase, alphanumeric, hyphens, no leading/trailing hyphens)
+- On blur (if format valid): calls `POST /repositories/validate-name`; emits `checking` then result
+- On type after a "taken" result: clears taken state immediately (user is correcting the name)
+
+### Accessibility
+
+- `<label>` explicitly associated with `<input>`
+- Status messages beneath the field use `role="status"` (checking) or `role="alert"` (errors)
+- Field has `aria-describedby` pointing to the status message element
+
+---
+
+## CMP-007: RepositoryTypePicker
+
+**Used by**: SCR-004 Step 2
+**Purpose**: Display repository type as either a read-only badge (fixed policy) or an editable
+dropdown (preferable/optional policy).
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `policy` | `'fixed' \| 'preferable' \| 'optional'` | Yes | How the template constrains the type choice |
+| `templateTypeName` | `string \| null` | No | Type name recommended or required by the template |
+| `availableTypes` | `RepositoryTypeOption[]` | Yes | List of types from the API (empty array when loading or unavailable) |
+| `selectedTypeName` | `string \| null` | Yes | Currently selected type (controlled) |
+| `loading` | `boolean` | No | Show loading state while type list fetches |
+| `disabled` | `boolean` | No | Disable interaction |
+
+```typescript
+type RepositoryTypeOption = { name: string; description: string };
+```
+
+### Events emitted
+
+- `change(typeName: string | null)` — user changed selection
+
+### Rendering rules
+
+- `fixed` policy: renders as a read-only row ("Repository type: [name]" with lock icon); no dropdown
+- `preferable` policy: renders as a dropdown pre-selected to `templateTypeName`; user can change
+- `optional` policy: renders as a dropdown with "No specific type" as first option
+
+---
+
+## CMP-008: VariableField
+
+**Used by**: SCR-004 Step 3
+**Purpose**: Single text input for one template variable.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `variableName` | `string` | Yes | Raw variable name (e.g., `service_name`) |
+| `label` | `string` | Yes | Human-readable label derived from `variableName` |
+| `description` | `string \| null` | No | Variable description shown as helper text |
+| `required` | `boolean` | Yes | Whether the variable must be filled |
+| `defaultValue` | `string \| null` | No | Pre-filled if present |
+| `value` | `string` | Yes | Current value (controlled) |
+| `disabled` | `boolean` | No | Disables the input |
+
+### Events emitted
+
+- `change(value: string)` — fires on every input change
+
+### Accessibility
+
+- `<label>` explicitly associated with `<input>`
+- Required fields: `aria-required="true"` and asterisk (*) in label
+- Helper text associated via `aria-describedby`
+
+---
+
+## CMP-009: RepositorySummary
+
+**Used by**: SCR-004 Step 2 (no-variable path) and Step 3; SCR-005
+**Purpose**: Read-only summary of the repository about to be (or just) created.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `organization` | `string` | Yes | Org name |
+| `repositoryName` | `string` | Yes | Repository name (may be empty string while user is typing) |
+| `templateName` | `string` | Yes | Selected template name |
+| `typeName` | `string \| null` | No | Repository type, if set |
+| `visibility` | `'private' \| 'public'` | Yes | Resolved visibility |
+| `teamName` | `string \| null` | No | Team name, if set |
+
+### Rendering
+
+- Displayed as an uneditable summary block: "[org] / [name]" with template, type, visibility chips
+- "name" field shown as a placeholder if empty (e.g., italicised "—")
+
+---
+
+## CMP-010: InlineAlert
+
+**Used by**: All screens
+**Purpose**: Non-modal status message for errors, warnings, info, or success.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `variant` | `'error' \| 'warning' \| 'info' \| 'success'` | Yes | Visual and semantic variant |
+| `message` | `string` | Yes | The alert message text |
+| `action` | `{ label: string; onClick: () => void } \| null` | No | Optional inline action link/button |
+
+### Accessibility
+
+- Uses `role="alert"` for `error` and `warning` variants (announced immediately)
+- Uses `role="status"` for `info` and `success` variants (polite announcement)
+- Action button/link is keyboard accessible
+
+---
+
+## CMP-011: CreationOverlay
+
+**Used by**: SCR-004 (during creation API call)
+**Purpose**: Full-area overlay shown while the creation request is in flight.
+
+### Props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `visible` | `boolean` | Yes | Whether the overlay is shown |
+
+### Accessibility
+
+- Overlay wrapper has `aria-live="polite"` on the status message
+- Spinner has `role="status"` and `aria-label="Creating repository"`
+- When visible, the underlying wizard content has `aria-hidden="true"` to prevent screen
+  reader navigation into it

--- a/docs/spec/ux/components/component-inventory.md
+++ b/docs/spec/ux/components/component-inventory.md
@@ -62,6 +62,11 @@ All interactive elements in this component (and all other components) reference
 
 ## CMP-001b: BrandCard
 
+> **Naming note**: BrandCard shares the `001` base number with AppShell because it addresses the
+> same brand-identity concern — unauthenticated screens cannot use the AppShell header but must
+> still display the same logo/wordmark. The `b` suffix makes the structural relationship explicit.
+> All other components are numbered sequentially from `002`.
+
 **Used by**: SCR-001, SCR-002, SCR-003
 **Purpose**: Centred card shell for unauthenticated screens (sign-in, OAuth callback, access denied).
 Displays the brand logo/wordmark above the card content, providing visual continuity with the
@@ -237,9 +242,10 @@ type NameValidationResult =
 ### Internal behaviour
 
 - On type: debounce 300ms → client-side format check
-- Format regex (client-side): `^[a-z0-9][a-z0-9-]*[a-z0-9]$` or single alphanumeric char
-  (mirrors GitHub naming rules — lowercase, alphanumeric, hyphens, no leading/trailing hyphens)
-- On blur (if format valid): calls `POST /repositories/validate-name`; emits `checking` then result
+- Format regex (client-side): `^[a-z0-9._-]+$` with additional rules: cannot start with `.`;
+  cannot contain `..` sequence (mirrors backend validation — see `api-request-types.md`, Repository
+  Names section)
+- On blur (if format valid): calls `POST /api/v1/repositories/validate-name`; emits `checking` then result
 - On type after a "taken" result: clears taken state immediately (user is correcting the name)
 
 ### Accessibility

--- a/docs/spec/ux/copy.md
+++ b/docs/spec/ux/copy.md
@@ -57,7 +57,7 @@ Use these strings verbatim in implementation. Do not use placeholder text like "
 | OAuth / network error | Message | There was a problem connecting to GitHub. This is usually temporary. |
 | OAuth / network error | Button | Try again |
 | User cancelled on GitHub | Heading `<h1>` | GitHub authorization was cancelled |
-| User cancelled on GitHub | Message | RepoRoller needs permission to read your GitHub identity to log who creates repositories. |
+| User cancelled on GitHub | Message | [App Name] needs permission to read your GitHub identity to log who creates repositories. |
 | User cancelled on GitHub | Button | Try again |
 | Not org member (future) | Heading `<h1>` | Access restricted to organization members |
 | Not org member (future) | Message | RepoRoller is available to members of [org] only. If you believe this is an error, contact your administrator. |
@@ -98,11 +98,11 @@ Use these strings verbatim in implementation. Do not use placeholder text like "
 | Step label (in progress indicator) | Settings |
 | Repository name label | Repository name |
 | Repository name placeholder | e.g. my-new-service |
-| Repository name helper text | Lowercase letters, numbers, and hyphens only. Must be unique in the organization. |
+| Repository name helper text | Lowercase letters, numbers, hyphens, underscores, and dots. Must be unique in the organization. Cannot start with a dot. |
 | Name checking indicator | Checking availability… |
 | Name available indicator | Available |
 | Name taken error | '[name]' is already taken in this organization. |
-| Name format error | Repository names may only contain lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen. |
+| Name format error | Repository names may only contain lowercase letters, numbers, hyphens (-), underscores (_), and dots (.). Names cannot start with a dot. |
 | Name availability check failed warning | Could not check availability. You can still proceed, but the name may already exist. |
 | Repository type label | Repository type |
 | Repository type fixed helper | This template requires a specific repository type. |
@@ -141,6 +141,7 @@ Use these strings verbatim in implementation. Do not use placeholder text like "
 | Spinner aria-label | Creating repository |
 | Overlay heading | Creating your repository… |
 | Overlay sub-message | This may take up to a minute. Please don't close this page. |
+| Overlay timeout error | Could not reach the server. Check your connection and try again. |
 
 ### Creation errors (InlineAlert messages)
 

--- a/docs/spec/ux/copy.md
+++ b/docs/spec/ux/copy.md
@@ -1,0 +1,181 @@
+# Copy Reference
+
+All user-facing strings in the RepoRoller web UI, organized by screen and component.
+
+> **`[App Name]`** is a placeholder for the value of `brand.app_name` in the deployment
+> branding configuration. The default value is `"RepoRoller"`. See [branding.md](branding.md)
+> for configuration details.
+>
+> All page `<title>` elements follow the pattern: `[screen name] — [App Name]`.
+
+Use these strings verbatim in implementation. Do not use placeholder text like "Loading..." or
+"Error" without a corresponding entry here.
+
+---
+
+## Global
+
+| Element | Copy |
+|---|---|
+| App name | `[App Name]` (configured; default: RepoRoller) |
+| Browser tab suffix | `— [App Name]` |
+| Sign out (menu item) | Sign out |
+| Back button | ← Back |
+
+---
+
+## SCR-001: Sign In
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Sign in — [App Name] |
+| Heading `<h1>` | Sign in to [App Name] |
+| Description | Create standardized GitHub repositories from your organization's templates. |
+| Sign-in button (default) | Sign in with GitHub |
+| Sign-in button (loading/redirecting) | Redirecting to GitHub… |
+
+---
+
+## SCR-002: OAuth Callback
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Signing in… — [App Name] |
+| Heading `<h1>` | Completing sign-in |
+| Status message | You'll be redirected in a moment. |
+| Error heading (client-side fallback) | Sign-in could not be completed. |
+| Error link | Try again |
+
+---
+
+## SCR-003: Access Denied
+
+| State | Element | Copy |
+|---|---|---|
+| OAuth / network error | Page `<title>` | Access denied — [App Name] |
+| OAuth / network error | Heading `<h1>` | Sign-in could not be completed |
+| OAuth / network error | Message | There was a problem connecting to GitHub. This is usually temporary. |
+| OAuth / network error | Button | Try again |
+| User cancelled on GitHub | Heading `<h1>` | GitHub authorization was cancelled |
+| User cancelled on GitHub | Message | RepoRoller needs permission to read your GitHub identity to log who creates repositories. |
+| User cancelled on GitHub | Button | Try again |
+| Not org member (future) | Heading `<h1>` | Access restricted to organization members |
+| Not org member (future) | Message | RepoRoller is available to members of [org] only. If you believe this is an error, contact your administrator. |
+| Not org member (future) | Button | Back to sign-in |
+
+---
+
+## SCR-004: Create Repository
+
+### Wizard chrome
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Create repository — [App Name] |
+| Step indicator aria-label pattern | Step [n] of [total]: [step label] |
+
+### Step 1: Choose a Template
+
+| Element | Copy |
+|---|---|
+| Step heading `<h1>` | Choose a template |
+| Step label (in progress indicator) | Choose template |
+| Search bar placeholder | Search templates |
+| Search bar label | Search templates |
+| No-results message | No templates match '[query]' |
+| Template list empty state | No templates are configured for this organization. Contact your platform team. |
+| Template list error message | Could not load templates. |
+| Template list retry button | Try again |
+| Template detail fetch error | Could not load template details. |
+| Template detail fetch retry link | Retry |
+| Next button | Next: Repository settings → |
+
+### Step 2: Repository Settings
+
+| Element | Copy |
+|---|---|
+| Step heading `<h1>` | Repository settings |
+| Step label (in progress indicator) | Settings |
+| Repository name label | Repository name |
+| Repository name placeholder | e.g. my-new-service |
+| Repository name helper text | Lowercase letters, numbers, and hyphens only. Must be unique in the organization. |
+| Name checking indicator | Checking availability… |
+| Name available indicator | Available |
+| Name taken error | '[name]' is already taken in this organization. |
+| Name format error | Repository names may only contain lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen. |
+| Name availability check failed warning | Could not check availability. You can still proceed, but the name may already exist. |
+| Repository type label | Repository type |
+| Repository type fixed helper | This template requires a specific repository type. |
+| Repository type preferable helper | Recommended by this template, but you can choose a different type. |
+| Repository type optional default option | No specific type |
+| Team label | Team (optional) |
+| Team default option | No specific team |
+| Team helper text | Select your team to apply team-specific configuration defaults. |
+| Team loading state | Loading teams… |
+| Team unavailable info | Team configuration unavailable. |
+| Visibility label | Visibility |
+| Visibility private option | Private |
+| Visibility public option | Public |
+| Visibility private helper | Only organization members can see this repository. |
+| Visibility public helper | Anyone on the internet can see this repository. |
+| Next button (has variables) | Next: Variables → |
+| Create button (no variables) | Create Repository |
+| Summary label prefix | You are about to create: |
+
+### Step 3: Template Variables
+
+| Element | Copy |
+|---|---|
+| Step heading `<h1>` | Template variables |
+| Step label (in progress indicator) | Variables |
+| Variable field placeholder | Enter a value |
+| Required field marker (visual) | * |
+| Required field aria suffix | (required) |
+| Create button | Create Repository |
+| Summary label prefix | You are about to create: |
+
+### Creation overlay
+
+| Element | Copy |
+|---|---|
+| Spinner aria-label | Creating repository |
+| Overlay heading | Creating your repository… |
+| Overlay sub-message | This may take up to a minute. Please don't close this page. |
+
+### Creation errors (InlineAlert messages)
+
+| Error scenario | Copy |
+|---|---|
+| Name taken (race condition) | A repository named '[name]' was created while you were filling in this form. Please choose a different name. |
+| Template no longer available | The template '[name]' is no longer available. Please choose a different template. |
+| Permission denied | You don't have permission to create repositories in this organization. Contact your administrator. |
+| GitHub API error | GitHub is temporarily unavailable. Your repository was not created. Please try again. |
+| Network error | Could not reach the server. Check your connection and try again. |
+
+---
+
+## SCR-005: Repository Created
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Repository created — [App Name] |
+| Heading `<h1>` | Repository created! |
+| Applied config summary toggle label | What was applied |
+| "View on GitHub" button | View repository on GitHub |
+| "View on GitHub" aria-label pattern | View [org/name] on GitHub (opens in new tab) |
+| "Create another" button | Create another repository |
+| Invalid state message | Your repository was created. Check your GitHub organization to find it. |
+
+---
+
+## SCR-006: Error
+
+| State | Element | Copy |
+|---|---|---|
+| Generic | Page `<title>` | Error — [App Name] |
+| Generic | Heading `<h1>` | Something went wrong |
+| Generic | Message | An unexpected error occurred. If this keeps happening, contact your platform team. |
+| Generic | Button | Try again |
+| Session expired | Heading `<h1>` | Your session has expired |
+| Session expired | Message | Please sign in again to continue. |
+| Session expired | Button | Sign in |

--- a/docs/spec/ux/copy.md
+++ b/docs/spec/ux/copy.md
@@ -60,7 +60,7 @@ Use these strings verbatim in implementation. Do not use placeholder text like "
 | User cancelled on GitHub | Message | [App Name] needs permission to read your GitHub identity to log who creates repositories. |
 | User cancelled on GitHub | Button | Try again |
 | Not org member (future) | Heading `<h1>` | Access restricted to organization members |
-| Not org member (future) | Message | RepoRoller is available to members of [org] only. If you believe this is an error, contact your administrator. |
+| Not org member (future) | Message | [App Name] is available to members of [org] only. If you believe this is an error, contact your administrator. |
 | Not org member (future) | Button | Back to sign-in |
 
 ---

--- a/docs/spec/ux/flows/authentication.md
+++ b/docs/spec/ux/flows/authentication.md
@@ -1,0 +1,73 @@
+# Authentication Flow
+
+## Overview
+
+RepoRoller uses GitHub OAuth to establish user identity. The VPN provides access control;
+OAuth provides the verified GitHub username that is recorded in the creation audit log.
+
+Org membership is **not enforced at sign-in** in this release. The architecture is designed so
+that a membership check can be added to the OAuth callback handler later without changes to
+the front-end flow.
+
+---
+
+## User Goal: Sign in and reach the creation form
+
+### Flow Diagram
+
+```mermaid
+flowchart TD
+    A([User opens RepoRoller]) --> B{Has valid session?}
+    B -->|Yes| C([Create Repository screen])
+    B -->|No| D[Sign In screen]
+
+    D --> E{User clicks 'Sign in with GitHub'}
+    E --> F[Redirect to GitHub OAuth authorization page]
+
+    F --> G{User action on GitHub}
+    G -->|Authorizes the app| H[GitHub redirects to /auth/callback with code]
+    G -->|Denies authorization| I[GitHub redirects to /auth/callback with error=access_denied]
+    G -->|No action / closes tab| J([User abandoned — no redirect])
+
+    H --> K[OAuth Callback screen: 'Completing sign-in...']
+    K --> L{Backend: exchange code for token}
+
+    L -->|Token exchange succeeds| M{Backend: get GitHub user identity}
+    M -->|Identity retrieved| N{Future: check org membership}
+    N -->|Member — or check not enforced| O[Create session with GitHub username]
+    N -->|Not a member| P[Redirect to /auth/denied]
+    M -->|Identity lookup fails| Q[Redirect to /auth/denied with reason=identity_failure]
+
+    L -->|Token exchange fails — GitHub error| R[Redirect to /auth/denied with reason=oauth_error]
+    L -->|Token exchange fails — network error| S[Redirect to /auth/denied with reason=network_error]
+
+    O --> C
+
+    P --> T[Access Denied screen]
+    Q --> T
+    R --> T
+    I --> T
+    S --> T
+```
+
+---
+
+## Session Lifecycle
+
+| Event | Behaviour |
+|---|---|
+| Successful OAuth | Session cookie set (HTTP-only, Secure, SameSite=Lax); user redirected to `/create` |
+| Session active | All requests to `/create` and `/create/success` proceed without re-authentication |
+| Session expired (future) | User redirected to `/sign-in`; redirect back to `/create` after successful sign-in |
+| User clicks Sign out | Session destroyed; user redirected to `/sign-in` |
+| OAuth error or denial | Session not created; user redirected to `/auth/denied` with `reason` parameter |
+
+---
+
+## Assumptions
+
+- Session management is handled by the SvelteKit backend (server-side sessions or signed cookies).
+- GitHub OAuth App credentials (client ID, client secret) are configured at deployment.
+- The `read:user` scope is requested to retrieve the GitHub login (`GET /user`).
+- The `read:org` scope is requested to support future org membership checks without a re-auth flow.
+- The OAuth callback URL registered with the GitHub App is `/auth/callback`.

--- a/docs/spec/ux/flows/repository-creation.md
+++ b/docs/spec/ux/flows/repository-creation.md
@@ -1,0 +1,118 @@
+# Repository Creation Flow
+
+## Overview
+
+The repository creation flow is the primary function of the web UI. It walks the user through a
+2–3 step wizard to select a template, configure the repository, supply template variables, and
+submit the creation request. Step 3 (variables) is skipped when the selected template defines
+no variables.
+
+---
+
+## User Goal: Create a fully-configured GitHub repository
+
+### Happy Path Flow
+
+```mermaid
+flowchart TD
+    A([User arrives at /create]) --> B[Load template list from API]
+    B --> C{Template list result}
+    C -->|Success| D[Step 1: Choose a Template]
+    C -->|Empty list| E[Empty state: No templates configured]
+    C -->|API error| F[Error state: Could not load templates]
+
+    F --> G{User clicks Retry}
+    G --> B
+
+    D --> H{User selects a template}
+    H --> I[Fetch template details from API]
+    I --> J{Template details result}
+    J -->|Success| K[Next button activates]
+    J -->|Error| L[Error banner: Could not load template details. Try again.]
+    L --> M{User retries fetch}
+    M --> I
+
+    K --> N{User clicks Next}
+    N --> O[Step 2: Repository Settings]
+
+    O --> P{User fills in repository name}
+    P --> Q{Name format valid? client-side}
+    Q -->|Invalid format| R[Inline error: format message]
+    Q -->|Valid format| S{User leaves name field}
+    S --> T[API: validate name uniqueness]
+    T --> U{Validation result}
+    U -->|Available| V[Name field shows green 'Available' indicator]
+    U -->|Already taken| W[Name field shows 'already taken' error]
+    U -->|API error| X[Name field shows 'Could not check availability' warning]
+
+    V --> Y{User completes Step 2}
+
+    Y --> Z{Template has variables?}
+    Z -->|No variables| AA[Show inline summary + Create button in Step 2]
+    Z -->|Has variables| AB[Next button: 'Next: Variables']
+
+    AA --> AC{User clicks Create Repository}
+    AB --> AD{User clicks Next}
+    AD --> AE[Step 3: Template Variables]
+    AE --> AF{User fills in required variables}
+    AF --> AG{All required variables filled?}
+    AG -->|No| AH[Create button remains disabled]
+    AG -->|Yes| AI[Show repository summary + Create button active]
+    AI --> AC
+
+    AC --> AJ[Creating overlay: spinner + message]
+    AJ --> AK[POST /api/v1/repositories]
+    AK --> AL{Creation result}
+
+    AL -->|201 Created| AM[Redirect to /create/success]
+    AM --> AN([Repository Created screen])
+
+    AL -->|422 Name taken - race condition| AO[Return to Step 2: name-taken error highlighted]
+    AL -->|422 Template not found| AP[Return to Step 1: template removed error banner]
+    AL -->|403 Permission denied| AQ[Inline error on Step 3 or 2: permission message]
+    AL -->|5xx GitHub error| AR[Inline error: GitHub unavailable]
+    AL -->|Network error| AS[Inline error: Could not reach server]
+```
+
+---
+
+## Step Structure
+
+| Step | Name | Required for all flows |
+|---|---|---|
+| Step 1 | Choose a Template | Always |
+| Step 2 | Repository Settings | Always |
+| Step 3 | Template Variables | Only when selected template has ≥1 variable |
+
+---
+
+## Back Navigation Within the Wizard
+
+| From | Back action | State preserved |
+|---|---|---|
+| Step 2 | Returns to Step 1 | Previously selected template card remains selected |
+| Step 3 | Returns to Step 2 | All Step 2 field values preserved (name, type, team, visibility) |
+| Step 1 | Back goes to browser history (leaves /create) | Unsaved-data warning dialog shown if name was entered |
+
+---
+
+## Leaving the Page Mid-Flow
+
+If the user has entered data in the creation form (at minimum: selected a template) and attempts
+to navigate away (browser back, closing tab, following a link), the browser's native unload event
+shows a confirmation: "Are you sure you want to leave? Your repository settings will be lost."
+
+This guard is removed once creation succeeds (navigation to `/create/success` is intentional) and
+while the creation overlay is active (to prevent partial interruption).
+
+---
+
+## Template Details Loading Strategy
+
+Template details (including variable definitions) are fetched when the user **selects** a template
+card in Step 1 (not when they click Next). This means by the time the user clicks Next, the detail
+fetch is either already complete or nearly so, avoiding a visible loading delay on the Step 2
+transition.
+
+If the details fetch fails, an error banner is shown below the template card and the Next button
+remains disabled until either the user retries the fetch or selects a different template.

--- a/docs/spec/ux/navigation.md
+++ b/docs/spec/ux/navigation.md
@@ -80,4 +80,4 @@ Sign-out is available on all authenticated screens via the UserBadge dropdown in
 
 | Link | Destination | Behaviour |
 |---|---|---|
-| Repository link on SCR-005 | `https://github.com/{org}/{name}` | Opens in new tab (`target="_blank"`, `rel="noopener"`) |
+| Repository link on SCR-005 | `https://github.com/{org}/{name}` | Opens in new tab (`target="_blank"`, `rel="noopener noreferrer"`) |

--- a/docs/spec/ux/navigation.md
+++ b/docs/spec/ux/navigation.md
@@ -1,0 +1,83 @@
+# Navigation Map
+
+## Route Inventory
+
+| Route | Screen | Auth required | Notes |
+|---|---|---|---|
+| `/` | — | — | Redirects to `/create` if session exists, else `/sign-in` |
+| `/sign-in` | SCR-001 | No | GitHub OAuth initiation |
+| `/auth/callback` | SCR-002 | No | OAuth callback handler; transitions to `/create` or `/auth/denied` |
+| `/auth/denied` | SCR-003 | No | Auth failure; `reason` query parameter selects copy variant |
+| `/create` | SCR-004 | Yes | Multi-step creation wizard (step state held in memory, not URL) |
+| `/create/success` | SCR-005 | Yes | Post-creation confirmation; `repo` query parameter carries full repo name |
+| `/error` | SCR-006 | Optional | System error fallback |
+
+---
+
+## Authentication Guard
+
+Any attempt to access a route marked "Auth required" without a valid session results in:
+
+- Immediate redirect to `/sign-in`
+- No 401 error page shown to the user
+- The originally requested URL is **not** preserved (all authenticated users land at `/create`)
+
+---
+
+## Step Navigation Within SCR-004
+
+Step navigation is managed entirely by component state inside `/create`. No URL changes occur
+between steps.
+
+| From | To | Trigger |
+|---|---|---|
+| Step 1 | Step 2 | User clicks "Next: Repository settings" (template selected + details loaded) |
+| Step 2 | Step 3 | User clicks "Next: Variables" (template has variables + name is valid) |
+| Step 2 | Creation overlay | User clicks "Create Repository" (template has no variables + name is valid + required fields complete) |
+| Step 3 | Creation overlay | User clicks "Create Repository" (all required variables filled) |
+| Step 2 | Step 1 | User clicks "← Back" |
+| Step 3 | Step 2 | User clicks "← Back" |
+| Any step | Browser history | Browser back button; unsaved-data guard fires if data entered |
+
+---
+
+## Post-Creation Navigation
+
+| From | To | Trigger |
+|---|---|---|
+| SCR-004 (creation overlay) | SCR-005 | 201 Created response from API |
+| SCR-004 (creation overlay) | SCR-004 (Step 2 with error) | 422 name taken |
+| SCR-004 (creation overlay) | SCR-004 (Step 1 with error) | 422 template not found |
+| SCR-005 | SCR-004 | "Create another repository" button |
+| SCR-005 | GitHub (new tab) | "View repository on GitHub" button |
+
+---
+
+## Sign-Out Navigation
+
+Sign-out is available on all authenticated screens via the UserBadge dropdown in the AppShell.
+
+| From | To | Trigger |
+|---|---|---|
+| Any authenticated screen | `/sign-in` | User clicks "Sign out" in UserBadge dropdown |
+
+---
+
+## Back Button Behaviour
+
+| Screen | Browser back behaviour |
+|---|---|
+| `/sign-in` | Goes to browser history (wherever user came from) |
+| `/auth/callback` | Should have no back history entry (replace rather than push); navigating back goes to `/sign-in` |
+| `/auth/denied` | "Try again" button is the intended recovery action; browser back not expected |
+| `/create` (any step) | Triggers unsaved-data guard if data entered; user confirms to leave |
+| `/create/success` | Goes to `/create` (intentional — user may want to create another) |
+| `/error` | Goes to browser history |
+
+---
+
+## External Links
+
+| Link | Destination | Behaviour |
+|---|---|---|
+| Repository link on SCR-005 | `https://github.com/{org}/{name}` | Opens in new tab (`target="_blank"`, `rel="noopener"`) |

--- a/docs/spec/ux/screens/SCR-001-sign-in.md
+++ b/docs/spec/ux/screens/SCR-001-sign-in.md
@@ -1,0 +1,103 @@
+# SCR-001: Sign In
+
+**Route**: `/sign-in`
+**Goal served**: First-time user authenticates to establish identity
+**Entry points**: Direct URL access; redirect from any protected route when no session exists
+**Exit points**: `/auth/callback` (system-triggered after GitHub OAuth redirect)
+
+---
+
+## Wireframe
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│              [ logo image | App Name ]                  │
+│                                                         │
+│           Sign in to [App Name]                         │
+│                                                         │
+│  Create standardized GitHub repositories from your      │
+│  organization's templates.                              │
+│                                                         │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │  [GitHub mark]   Sign in with GitHub              │  │
+│  └───────────────────────────────────────────────────┘  │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+- The card is centred in the viewport (horizontal + vertical)
+- Logo/wordmark is centred above the card heading
+- The sign-in button spans most of the card width
+- No navigation, no links, no footer
+
+---
+
+## Purpose
+
+Allow an org member to sign in with their GitHub account. No credentials are entered here —
+the user is sent to GitHub to authenticate. This screen's sole purpose is to explain the tool
+briefly and provide the single sign-in action.
+
+---
+
+## Layout
+
+- Centred card, single column, vertically centred on the viewport
+- RepoRoller logo/wordmark at top
+- One-line description of what the tool does
+- "Sign in with GitHub" button (prominent, GitHub-branded style)
+- No navigation, no header, no footer (intentional — this is a full-screen gate)
+
+---
+
+## States
+
+### Default
+
+- "Sign in with GitHub" button: enabled
+- No error messages visible
+
+### Loading (after button click, before GitHub redirect)
+
+- Button: disabled, label changes to "Redirecting to GitHub…"
+- Spinner replaces the GitHub icon on the button
+- Duration: typically < 500ms before browser navigates away; no timeout handling needed here
+
+---
+
+## Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| Sign in with GitHub button | Click | Button enters loading state; browser navigates to GitHub OAuth authorization URL |
+
+---
+
+## Accessibility
+
+- Single `<h1>`: "Sign in to RepoRoller"
+- Button is the page's primary action; Enter key triggers it
+- No autofocus needed (single interactive element)
+- Button has sufficient contrast in both default and loading states
+- Minimum touch target: 44×44px
+
+---
+
+## Copy
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Sign in — RepoRoller |
+| Heading `<h1>` | Sign in to RepoRoller |
+| Description | Create standardized GitHub repositories from your organization's templates. |
+| Button (default) | Sign in with GitHub |
+| Button (loading) | Redirecting to GitHub… |
+
+---
+
+## Data Requirements
+
+- **Inputs**: none (user supplies no data on this screen)
+- **Outputs (events)**: `initiateOAuth()` — triggers redirect to GitHub authorization endpoint
+- **No async data loading** on this screen

--- a/docs/spec/ux/screens/SCR-001-sign-in.md
+++ b/docs/spec/ux/screens/SCR-001-sign-in.md
@@ -44,7 +44,7 @@ briefly and provide the single sign-in action.
 ## Layout
 
 - Centred card, single column, vertically centred on the viewport
-- RepoRoller logo/wordmark at top
+- [App Name] logo/wordmark at top
 - One-line description of what the tool does
 - "Sign in with GitHub" button (prominent, GitHub-branded style)
 - No navigation, no header, no footer (intentional — this is a full-screen gate)
@@ -76,7 +76,7 @@ briefly and provide the single sign-in action.
 
 ## Accessibility
 
-- Single `<h1>`: "Sign in to RepoRoller"
+- Single `<h1>`: "Sign in to [App Name]"
 - Button is the page's primary action; Enter key triggers it
 - No autofocus needed (single interactive element)
 - Button has sufficient contrast in both default and loading states
@@ -88,8 +88,8 @@ briefly and provide the single sign-in action.
 
 | Element | Copy |
 |---|---|
-| Page `<title>` | Sign in — RepoRoller |
-| Heading `<h1>` | Sign in to RepoRoller |
+| Page `<title>` | Sign in — [App Name] |
+| Heading `<h1>` | Sign in to [App Name] |
 | Description | Create standardized GitHub repositories from your organization's templates. |
 | Button (default) | Sign in with GitHub |
 | Button (loading) | Redirecting to GitHub… |

--- a/docs/spec/ux/screens/SCR-002-oauth-callback.md
+++ b/docs/spec/ux/screens/SCR-002-oauth-callback.md
@@ -86,7 +86,7 @@ There are no user interactions on this screen. Navigation is system-driven.
 
 | Element | Copy |
 |---|---|
-| Page `<title>` | Signing in… — RepoRoller |
+| Page `<title>` | Signing in… — [App Name] |
 | Heading `<h1>` | Completing sign-in |
 | Status message | You'll be redirected in a moment. |
 | Error heading | Sign-in could not be completed. |

--- a/docs/spec/ux/screens/SCR-002-oauth-callback.md
+++ b/docs/spec/ux/screens/SCR-002-oauth-callback.md
@@ -1,0 +1,102 @@
+# SCR-002: OAuth Callback
+
+**Route**: `/auth/callback`
+**Goal served**: Completing the GitHub OAuth exchange and establishing a session
+**Entry points**: GitHub OAuth redirect (system-triggered, user cannot navigate here directly)
+**Exit points**: `/create` (success); `/auth/denied` (failure or denial)
+
+---
+
+## Wireframe
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│              [ logo image | App Name ]                  │
+│                                                         │
+│                 Completing sign-in                      │
+│                                                         │
+│                      ( ↻ )                              │
+│                 (animated spinner)                      │
+│                                                         │
+│         You'll be redirected in a moment.               │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Same centred card layout as SCR-001
+- No interactive elements; spinner is the only animated element
+- Logo/wordmark provides brand continuity with the sign-in screen
+
+---
+
+## Purpose
+
+This is an intermediate screen the user sees briefly while the server-side OAuth token exchange
+completes. It provides reassurance that something is happening. Users should spend no more than
+2–3 seconds on this screen under normal conditions.
+
+---
+
+## Layout
+
+- Identical visual shell to the Sign In screen (centred card, no navigation)
+- Spinner (animated)
+- Status message
+- No user actions available
+
+---
+
+## States
+
+### Completing sign-in (default — shown while token exchange is in progress)
+
+- Spinner: visible and animating
+- Message: "Completing sign-in…"
+- Sub-message: "You'll be redirected in a moment."
+- No buttons or links
+
+### Error (if callback URL contains `error` parameter from GitHub, or server-side failure is detected before redirect)
+
+This state is typically not rendered — the server handles the error and immediately redirects to
+`/auth/denied`. However, if client-side JavaScript detects an `error` query parameter before the
+server processes it:
+
+- Spinner: hidden
+- Message: "Sign-in could not be completed."
+- Link: "Try again" → `/sign-in`
+
+---
+
+## Interactions
+
+There are no user interactions on this screen. Navigation is system-driven.
+
+---
+
+## Accessibility
+
+- Single `<h1>`: "Completing sign-in"
+- Spinner has `role="status"` and `aria-label="Signing in"`
+- No keyboard trap — if the redirect never fires, the user can navigate away using browser controls
+
+---
+
+## Copy
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Signing in… — RepoRoller |
+| Heading `<h1>` | Completing sign-in |
+| Status message | You'll be redirected in a moment. |
+| Error heading | Sign-in could not be completed. |
+| Error link | Try again |
+
+---
+
+## Data Requirements
+
+- **Inputs**: `code` query parameter (from GitHub), `state` query parameter (CSRF token)
+- **Server action**: Exchange code for token; retrieve GitHub user identity (`GET /user`);
+  create session; redirect
+- **No user-visible data** on this screen beyond the status message

--- a/docs/spec/ux/screens/SCR-003-access-denied.md
+++ b/docs/spec/ux/screens/SCR-003-access-denied.md
@@ -37,7 +37,7 @@
 │                                                         │
 │         ✕  GitHub authorization was cancelled           │
 │                                                         │
-│  RepoRoller needs permission to read your GitHub        │
+|  [App Name] needs permission to read your GitHub        |
 │  identity to log who creates repositories.              │
 │                                                         │
 │  ┌───────────────────────────────────────────────────┐  │
@@ -90,7 +90,7 @@ or the identity lookup failed).
 Shown when the user clicked "Cancel" on the GitHub authorization page.
 
 - Heading: "GitHub authorization was cancelled"
-- Message: "RepoRoller needs permission to read your GitHub identity to log who creates repositories."
+- Message: "[App Name] needs permission to read your GitHub identity to log who creates repositories."
 - Primary action button: "Try again" → `/sign-in`
 
 ### Org membership required (reason=not_org_member) — future
@@ -98,7 +98,7 @@ Shown when the user clicked "Cancel" on the GitHub authorization page.
 Shown when the org membership check is enabled and the user is not a member of the required org.
 
 - Heading: "Access restricted to organization members"
-- Message: "RepoRoller is available to members of [Org Name] only. If you believe this is an
+- Message: "[App Name] is available to members of [Org Name] only. If you believe this is an
   error, contact your administrator."
 - Primary action button: "Back to sign-in" → `/sign-in`
 
@@ -125,15 +125,15 @@ Shown when the org membership check is enabled and the user is not a member of t
 
 | Element | Copy |
 |---|---|
-| Page `<title>` | Access denied — RepoRoller |
+| Page `<title>` | Access denied — [App Name] |
 | OAuth error heading | Sign-in could not be completed |
 | OAuth error message | There was a problem connecting to GitHub. This is usually temporary. |
 | OAuth error button | Try again |
 | Access denied heading | GitHub authorization was cancelled |
-| Access denied message | RepoRoller needs permission to read your GitHub identity to log who creates repositories. |
+| Access denied message | [App Name] needs permission to read your GitHub identity to log who creates repositories. |
 | Access denied button | Try again |
 | Not org member heading | Access restricted to organization members |
-| Not org member message | RepoRoller is available to members of [org] only. If you believe this is an error, contact your administrator. |
+| Not org member message | [App Name] is available to members of [org] only. If you believe this is an error, contact your administrator. |
 | Not org member button | Back to sign-in |
 
 ---

--- a/docs/spec/ux/screens/SCR-003-access-denied.md
+++ b/docs/spec/ux/screens/SCR-003-access-denied.md
@@ -1,0 +1,146 @@
+# SCR-003: Access Denied
+
+**Route**: `/auth/denied`
+**Goal served**: Inform a user why sign-in could not be completed and what they can do
+**Entry points**: OAuth callback redirect (on OAuth error, denial, or org membership failure)
+**Exit points**: `/sign-in` (try again); GitHub org membership request (external link, when applicable)
+
+---
+
+## Wireframe
+
+**OAuth error variant** (most common at launch):
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│              [ logo image | App Name ]                  │
+│                                                         │
+│            ⚠  Sign-in could not be completed           │
+│                                                         │
+│  There was a problem connecting to GitHub. This is      │
+│  usually temporary.                                     │
+│                                                         │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │                  Try again                        │  │
+│  └───────────────────────────────────────────────────┘  │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Access denied variant** (user cancelled on GitHub):
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│              [ logo image | App Name ]                  │
+│                                                         │
+│         ✕  GitHub authorization was cancelled           │
+│                                                         │
+│  RepoRoller needs permission to read your GitHub        │
+│  identity to log who creates repositories.              │
+│                                                         │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │                  Try again                        │  │
+│  └───────────────────────────────────────────────────┘  │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Same centred card layout as SCR-001 and SCR-002
+- Icon variant (⚠ vs ✕) communicates nature of the problem at a glance
+- Single primary button — no secondary actions to create confusion
+
+---
+
+## Purpose
+
+This screen handles all failure cases from the authentication flow. It tells the user what went
+wrong without exposing internal error details, and provides a clear next action.
+
+In the current release, users only reach this screen via OAuth errors (not org membership checks,
+which are not yet enforced). The org-membership variant is specified here so it can be implemented
+without redesigning the screen.
+
+---
+
+## Layout
+
+- Same centred card shell as Sign In and OAuth Callback
+- Icon appropriate to the reason (warning or lock)
+- Heading appropriate to the reason
+- Explanatory message
+- One or two action buttons/links depending on reason
+
+---
+
+## States
+
+### OAuth error (reason=oauth_error, reason=network_error, reason=identity_failure)
+
+Shown when the GitHub OAuth exchange failed for technical reasons (GitHub outage, network error,
+or the identity lookup failed).
+
+- Heading: "Sign-in could not be completed"
+- Message: "There was a problem connecting to GitHub. This is usually temporary."
+- Primary action button: "Try again" → `/sign-in`
+
+### User denied access on GitHub (reason=access_denied)
+
+Shown when the user clicked "Cancel" on the GitHub authorization page.
+
+- Heading: "GitHub authorization was cancelled"
+- Message: "RepoRoller needs permission to read your GitHub identity to log who creates repositories."
+- Primary action button: "Try again" → `/sign-in`
+
+### Org membership required (reason=not_org_member) — future
+
+Shown when the org membership check is enabled and the user is not a member of the required org.
+
+- Heading: "Access restricted to organization members"
+- Message: "RepoRoller is available to members of [Org Name] only. If you believe this is an
+  error, contact your administrator."
+- Primary action button: "Back to sign-in" → `/sign-in`
+
+---
+
+## Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| "Try again" button | Click | Navigate to `/sign-in` |
+| "Back to sign-in" button | Click | Navigate to `/sign-in` |
+
+---
+
+## Accessibility
+
+- `<h1>` matches the state heading
+- Error message uses `role="alert"` — announced to screen readers on page load
+- No timed auto-redirect (user controls when to proceed)
+
+---
+
+## Copy
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Access denied — RepoRoller |
+| OAuth error heading | Sign-in could not be completed |
+| OAuth error message | There was a problem connecting to GitHub. This is usually temporary. |
+| OAuth error button | Try again |
+| Access denied heading | GitHub authorization was cancelled |
+| Access denied message | RepoRoller needs permission to read your GitHub identity to log who creates repositories. |
+| Access denied button | Try again |
+| Not org member heading | Access restricted to organization members |
+| Not org member message | RepoRoller is available to members of [org] only. If you believe this is an error, contact your administrator. |
+| Not org member button | Back to sign-in |
+
+---
+
+## Data Requirements
+
+- **Inputs**: `reason` query parameter (values: `oauth_error`, `network_error`, `identity_failure`, `access_denied`, `not_org_member`)
+- **No async data loading** — all content is static based on the `reason` parameter
+- **Security**: The `reason` parameter drives copy selection only. Internal error details are never
+  surfaced to the client.

--- a/docs/spec/ux/screens/SCR-004-create-repository.md
+++ b/docs/spec/ux/screens/SCR-004-create-repository.md
@@ -75,7 +75,7 @@ Selected state (rust-library chosen, details loaded):
 |  +----------------------------------------------------------+|
 |  | e.g. my-new-service                                      ||
 |  +----------------------------------------------------------+|
-|  Lowercase letters, numbers, and hyphens only.               |
+|  Lowercase letters, numbers, hyphens, underscores, dots.     |
 |                after blur → [ ✓ Available ]                  |
 |                                                              |
 |  Repository type                                             |
@@ -269,12 +269,16 @@ is ready without delay.
 - Template cards interactive
 - Next button: disabled
 
-#### Card selected
+#### Card selected — fetch in progress
 
 - Selected card: highlighted border, checkmark in top-right corner
-- Template details fetch begins in background (GET /orgs/{org}/templates/{template})
-- Next button: enabled (unless details fetch failed — see error state below)
+- Template details fetch begins immediately (`GET /api/v1/orgs/{org}/templates/{template}`)
+- Next button: **disabled** while the fetch is in-flight
 - Previously selected template (if user came back from Step 2): pre-selected on return
+
+#### Card selected — fetch complete
+
+- Next button: **enabled** — transitions automatically when the fetch succeeds; no user action required
 
 #### Template details fetch error (after card selection)
 
@@ -297,8 +301,8 @@ is ready without delay.
 
 | Element | Action | Outcome |
 |---|---|---|
-| Template card | Click | Card selected; details fetch begins; Next activates |
-| Different card (when one already selected) | Click | New card selected; details refetched; previous selection cleared |
+| Template card | Click | Card selected; details fetch begins; Next remains disabled until fetch succeeds |
+| Different card (when one already selected) | Click | New card selected; details refetched; previous selection cleared; Next disabled during refetch |
 | Search/filter bar | Type | Template cards filtered client-side (by name, description, tags); no API call |
 | Search bar cleared | Clear | All templates shown again |
 | Retry button (API error state) | Click | Template list refetched |
@@ -330,7 +334,7 @@ populated with defaults from the template or org configuration.
 - Label: "Repository name"
 - Input type: text
 - Placeholder: "e.g. my-new-service"
-- Helper text: "Lowercase letters, numbers, and hyphens only. Must be unique in the organization."
+- Helper text: "Lowercase letters, numbers, hyphens, underscores, and dots. Must be unique in the organization. Cannot start with a dot."
 - Validation behaviour:
   - **On type** (debounced 300ms): client-side format check only. Removes the "already taken" error
     immediately if the name changes.
@@ -358,7 +362,7 @@ Shown only when repository types are defined in the org configuration.
   - Dropdown, pre-selected to the template's preferred type
   - User can change it
   - Helper text: "Recommended by this template, but you can choose a different type."
-  - Dropdown options: all available repository types from `GET /orgs/{org}/repository-types`
+  - Dropdown options: all available repository types from `GET /api/v1/orgs/{org}/types`
 
   **Policy: `optional` or no policy**
   - Dropdown, default selection: "No specific type"
@@ -503,6 +507,10 @@ Displayed over the entire wizard while `POST /api/v1/repositories` is in flight.
 - Wizard step content is visually obscured (not removed from DOM — allows error recovery)
 - If the API call succeeds: navigates to `/create/success`
 - If the API call fails: overlay is dismissed; appropriate inline error is shown (see below)
+- **Timeout**: if no response is received within **90 seconds**, treat as a network error; dismiss
+  the overlay and show the "Could not reach the server. Check your connection and try again."
+  InlineAlert on the current step. The sub-message "This may take up to a minute" implies a
+  ~60-second expected maximum; the 90-second timeout adds a safety margin before giving up.
 
 ---
 
@@ -547,7 +555,7 @@ is dismissed before the error appears.
 |---|---|---|
 | Fetch template list | On step entry (page load) | `GET /api/v1/orgs/{org}/templates` |
 | Fetch template details | When user selects a template card | `GET /api/v1/orgs/{org}/templates/{template}` |
-| Fetch repository types | On step 2 entry (first time only) | `GET /api/v1/orgs/{org}/repository-types` |
+| Fetch repository types | On step 2 entry (first time only) | `GET /api/v1/orgs/{org}/types` |
 | Validate name uniqueness | On blur of name field (if format valid) | `POST /api/v1/repositories/validate-name` |
 | Create repository | On "Create Repository" click | `POST /api/v1/repositories` |
 

--- a/docs/spec/ux/screens/SCR-004-create-repository.md
+++ b/docs/spec/ux/screens/SCR-004-create-repository.md
@@ -1,0 +1,569 @@
+# SCR-004: Create Repository
+
+**Route**: `/create`
+**Goal served**: User creates a fully-configured GitHub repository
+**Entry points**: Redirect from `/auth/callback` (on first sign-in); direct navigation by returning users
+**Exit points**: `/create/success` (creation succeeded); `/sign-in` (session expired or sign-out)
+
+---
+
+## Wireframes
+
+### AppShell + Step 1: Choose a Template
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|  (1) Choose template  ---  (2) Settings  ---  (3) Variables  |
+|   ●                             ○                   ○        |
+|                                                              |
+|  Choose a template                                           |
+|                                                              |
+|  +----------------------------------------------------------+|
+|  | Search templates...                                      ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  +-------------------------+  +-------------------------+   |
+|  |  O  rust-library        |  |  O  python-service      |   |
+|  |  Rust library with      |  |  Python microservice    |   |
+|  |  CI/CD and testing      |  |  with FastAPI           |   |
+|  |  [rust] [library]       |  |  [python] [service]     |   |
+|  |  type: library          |  |  type: service          |   |
+|  +-------------------------+  +-------------------------+   |
+|                                                              |
+|  +-------------------------+  +-------------------------+   |
+|  |  O  github-action       |  |  O  docs-site           |   |
+|  |  GitHub Action          |  |  Documentation site     |   |
+|  |  template               |  |  with MkDocs            |   |
+|  |  [actions] [ci]         |  |  [docs] [mkdocs]        |   |
+|  +-------------------------+  +-------------------------+   |
+|                                                              |
+|                              [ Next: Repository settings → ] |
+|                                                              |
++==============================================================+
+```
+
+Selected state (rust-library chosen, details loaded):
+
+```
+|  +-------------------------+  +-------------------------+   |
+|  |  ✓  rust-library        |  |  O  python-service      |   |
+|  |  (highlighted border,   |  |                         |   |
+|  |   checkmark top-right)  |  |                         |   |
+|  +-------------------------+  +-------------------------+   |
+|                                                              |
+|                              [ Next: Repository settings → ] |  <- enabled
+```
+
+---
+
+### Step 2: Repository Settings (template has variables — shows "Next" button)
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|  (1) Choose template  ---  (2) Settings  ---  (3) Variables  |
+|   ✓                             ●                   ○        |
+|                                                              |
+|  Repository settings                                         |
+|                                                              |
+|  Repository name *                                           |
+|  +----------------------------------------------------------+|
+|  | e.g. my-new-service                                      ||
+|  +----------------------------------------------------------+|
+|  Lowercase letters, numbers, and hyphens only.               |
+|                after blur → [ ✓ Available ]                  |
+|                                                              |
+|  Repository type                                             |
+|  +----------------------------------------------------------+|
+|  | library  (pre-selected, preferable policy)           v   ||
+|  +----------------------------------------------------------+|
+|  Recommended by this template, but you can choose a          |
+|  different type.                                             |
+|                                                              |
+|  Team (optional)                                             |
+|  +----------------------------------------------------------+|
+|  | No specific team                                     v   ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  [ ← Back ]                       [ Next: Variables → ]     |
+|                                                              |
++==============================================================+
+```
+
+---
+
+### Step 2: Repository Settings (template has NO variables — shows "Create" button + summary)
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|  (1) Choose template  ---  (2) Settings                      |
+|   ✓                             ●                            |
+|                                                              |
+|  Repository settings                                         |
+|                                                              |
+|  Repository name *                                           |
+|  +----------------------------------------------------------+|
+|  | my-docs-site                                             ||
+|  +----------------------------------------------------------+|
+|  ✓ Available                                                 |
+|                                                              |
+|  Team (optional)                                             |
+|  +----------------------------------------------------------+|
+|  | No specific team                                     v   ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  +----------------------------------------------------------+|
+|  | You are about to create:                                 ||
+|  | myorg / my-docs-site   Template: docs-site   [private]  ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  [ ← Back ]                          [ Create Repository ]  |
+|                                                              |
++==============================================================+
+```
+
+---
+
+### Step 3: Template Variables
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|  (1) Choose template  ---  (2) Settings  ---  (3) Variables  |
+|   ✓                             ✓                   ●        |
+|                                                              |
+|  Template variables                                          |
+|                                                              |
+|  Service name *                                              |
+|  +----------------------------------------------------------+|
+|  |                                                          ||
+|  +----------------------------------------------------------+|
+|  The name of the service, used throughout the template.      |
+|                                                              |
+|  Author                                                      |
+|  +----------------------------------------------------------+|
+|  | Platform Team       (pre-filled default value)           ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  Description (optional)                                      |
+|  +----------------------------------------------------------+|
+|  |                                                          ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  +----------------------------------------------------------+|
+|  | You are about to create:                                 ||
+|  | myorg / my-new-service   Template: rust-library          ||
+|  | [library] [private]                                      ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|  [ ← Back ]                          [ Create Repository ]  |
+|                                                              |
++==============================================================+
+```
+
+---
+
+### Creation overlay (active during API call)
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|  ////////////////////////////////////////////////////////// |
+|  //  (wizard content dimmed beneath overlay)             // |
+|  //  +----------------------------------------------+   // |
+|  //  |                                              |   // |
+|  //  |       Creating your repository…              |   // |
+|  //  |                                              |   // |
+|  //  |               ( ⟳ )                          |   // |
+|  //  |          (animated spinner)                  |   // |
+|  //  |                                              |   // |
+|  //  |  This may take up to a minute. Please        |   // |
+|  //  |  don't close this page.                      |   // |
+|  //  |                                              |   // |
+|  //  +----------------------------------------------+   // |
+|  ////////////////////////////////////////////////////////// |
+|                                                              |
++==============================================================+
+```
+
+---
+
+## Purpose
+
+The primary screen of the application. A stepped wizard that collects:
+
+1. Template selection
+2. Repository settings (name, type, team, visibility)
+3. Template variable values (conditional — only shown when the template defines variables)
+
+Then submits the creation request and shows a loading overlay while the API call completes.
+
+---
+
+## Layout
+
+- Full-page authenticated layout: AppShell (header with logo + UserBadge) above the wizard area
+- Wizard area: centred, single column, max-width ~700px
+- Step progress indicator at the top of the wizard (e.g., "Step 1 of 3")
+- Step content below the indicator
+- Back / Next / Create buttons at the bottom of each step
+
+---
+
+## Global Wizard Behaviour
+
+- **Step state is held in component memory** (not in the URL). The route stays `/create` throughout.
+- **Back navigation within the wizard** is handled by the wizard's own Back button — not the browser
+  back button. Browser back navigates away from `/create` entirely.
+- **Unsaved-data guard**: if the user has selected a template (or entered any data) and
+  attempts to close the tab or navigate away via browser controls, the browser's native leave
+  confirmation dialog is shown.
+- **The guard is removed** once the creation overlay activates (to avoid interfering with the
+  redirect to `/create/success`) and once the user successfully completes creation.
+- Returning to a previous step preserves all previously entered values in later steps.
+
+---
+
+## Step 1: Choose a Template
+
+### Purpose
+
+Let the user select the template that will define the structure and configuration of their new
+repository. This step also loads the template's variable definitions in the background, so Step 3
+is ready without delay.
+
+### Layout
+
+- Heading: "Choose a template"
+- Optional search/filter bar (filters the displayed cards client-side, no API call)
+- Template card grid (2 columns desktop, 1 column mobile)
+- Each template card shows:
+  - Template name (bold)
+  - Description (clamped to 2 lines)
+  - Tags (small chips, max 4 shown)
+  - Repository type badge (if the template has a fixed or preferable type)
+- "Next: Repository settings →" button at the bottom: **disabled** until a card is selected
+
+### States
+
+#### Loading (fetching template list)
+
+- Search bar: disabled
+- Card grid replaced with 4 skeleton card placeholders (ghost loading)
+- Next button: disabled
+
+#### Loaded (template list available, no selection)
+
+- Template cards interactive
+- Next button: disabled
+
+#### Card selected
+
+- Selected card: highlighted border, checkmark in top-right corner
+- Template details fetch begins in background (GET /orgs/{org}/templates/{template})
+- Next button: enabled (unless details fetch failed — see error state below)
+- Previously selected template (if user came back from Step 2): pre-selected on return
+
+#### Template details fetch error (after card selection)
+
+- Error banner below the selected card: "Could not load template details. [Retry]"
+- Next button: disabled until fetch succeeds or user selects a different template
+
+#### Empty (no templates in the org)
+
+- No cards shown
+- Info message: "No templates are configured for this organization. Contact your platform team."
+- Next button: disabled permanently
+
+#### API error (failed to fetch template list)
+
+- No cards shown
+- Error message: "Could not load templates."
+- "Try again" button — triggers refetch of template list
+
+### Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| Template card | Click | Card selected; details fetch begins; Next activates |
+| Different card (when one already selected) | Click | New card selected; details refetched; previous selection cleared |
+| Search/filter bar | Type | Template cards filtered client-side (by name, description, tags); no API call |
+| Search bar cleared | Clear | All templates shown again |
+| Retry button (API error state) | Click | Template list refetched |
+| Retry link (details error state) | Click | Template details refetched for currently selected template |
+| "Next: Repository settings" button | Click | Transition to Step 2 |
+
+---
+
+## Step 2: Repository Settings
+
+### Purpose
+
+Collect the repository name and other settings that control how the repository is created.
+The name field validates availability in real-time. Repository type and other fields are
+populated with defaults from the template or org configuration.
+
+### Layout
+
+- Heading: "Repository settings"
+- Fields in order (see below)
+- If the selected template has **no variables**: inline summary section at the bottom + "Create Repository" primary button
+- If the selected template **has variables**: "Next: Variables →" button at the bottom
+- "← Back" secondary button at the bottom
+
+### Fields
+
+#### Repository name (required)
+
+- Label: "Repository name"
+- Input type: text
+- Placeholder: "e.g. my-new-service"
+- Helper text: "Lowercase letters, numbers, and hyphens only. Must be unique in the organization."
+- Validation behaviour:
+  - **On type** (debounced 300ms): client-side format check only. Removes the "already taken" error
+    immediately if the name changes.
+  - **On blur** (when the field loses focus, if format is valid): calls `POST /repositories/validate-name`
+    to check uniqueness
+  - **Format invalid** (client-side): shows error below field; no API call made
+  - **Format valid, checking** (API call in flight): shows spinner + "Checking availability…" below field; Next/Create button disabled
+  - **Valid and available**: shows green checkmark + "Available" below field
+  - **Valid but taken**: shows warning icon + "'[name]' is already taken in this organization." below field; Next/Create button disabled
+  - **Format valid, API check failed**: shows warning icon + "Could not check availability. You can still proceed, but the name may already exist." below field; Next/Create button enabled (with caveat)
+
+#### Repository type (conditional)
+
+Shown only when repository types are defined in the org configuration.
+
+- Label: "Repository type"
+- Three sub-cases based on the selected template's `repository_type.policy`:
+
+  **Policy: `fixed`**
+  - Not an editable input — displayed as a read-only info row:
+    "Repository type: [type name]" with a lock icon
+  - Helper text: "This template requires a specific repository type."
+
+  **Policy: `preferable`**
+  - Dropdown, pre-selected to the template's preferred type
+  - User can change it
+  - Helper text: "Recommended by this template, but you can choose a different type."
+  - Dropdown options: all available repository types from `GET /orgs/{org}/repository-types`
+
+  **Policy: `optional` or no policy**
+  - Dropdown, default selection: "No specific type"
+  - Dropdown options: "No specific type" + all available repository types
+
+#### Team (optional)
+
+- Label: "Team (optional)"
+- Input: dropdown
+- Default: "No specific team"
+- Options: org's teams (if team list API is available) — fetched on step entry, not on page load
+- Helper text: "Select your team to apply team-specific configuration defaults."
+- Loading state when fetching teams: dropdown shows "Loading teams…" and is disabled
+- Error state if teams fetch fails: dropdown hidden, replaced with info: "Team configuration unavailable."
+
+#### Visibility (conditional)
+
+Shown only if the org configuration permits user visibility override. Hidden by default in the
+initial release (assume org-enforced visibility).
+
+- Label: "Visibility"
+- Input: radio group
+  - "Private" (default)
+  - "Public"
+- Helper text for Private: "Only organization members can see this repository."
+- Helper text for Public: "Anyone on the internet can see this repository."
+
+### Inline Summary (when template has no variables)
+
+Displayed below the fields before the Create button:
+
+```
+You are about to create:
+[org name] / [repository name]    Template: [template name]    [Type badge]    [Visibility badge]
+```
+
+All parts update live as the user fills in the form.
+
+### Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| Repository name field | Type | Client-side format validation on debounce; "taken" error cleared |
+| Repository name field | Blur (valid format) | API uniqueness check triggered |
+| Repository name field | Blur (invalid format) | No API call; format error remains |
+| Repository type dropdown | Change | Selected type updates; summary updates |
+| Team dropdown | Change | Selected team updates |
+| Visibility radio | Change | Visibility updates; summary updates |
+| "← Back" button | Click | Return to Step 1; previously selected template card still selected |
+| "Next: Variables" button | Click | Transition to Step 3; button visible only when template has variables |
+| "Create Repository" button | Click | Validation check → if all valid, show creation overlay and submit |
+
+### Next / Create button activation rules
+
+The Next / Create button is **enabled** when:
+
+- Repository name field: format is valid AND uniqueness check result is "Available" (or "check failed" warning state)
+
+The Next / Create button is **disabled** when:
+
+- Repository name is empty
+- Repository name format is invalid
+- Uniqueness check is in progress
+- Uniqueness check returned "already taken"
+
+---
+
+## Step 3: Template Variables
+
+### Purpose
+
+Collect values for the template-specific variables that will be substituted into the template
+content. Only shown when the selected template defines at least one variable.
+
+### Layout
+
+- Heading: "Template variables"
+- Variable fields in order: required variables first, then optional
+- Required variables marked with an asterisk (*) in the label
+- Inline summary section at the bottom (same as Step 2's summary when no variables)
+- "Create Repository" primary button at the bottom
+- "← Back" secondary button at the bottom
+
+### Variable Field Rendering
+
+Each variable from the template's `variables[]` array is rendered as a `VariableField` component:
+
+- **Label**: variable `name` formatted as a human-readable label (e.g., `service_name` → "Service name")
+- **Required marker**: asterisk if `required: true`
+- **Description**: if `variable.description` is provided, shown as helper text below the field
+- **Placeholder**: variable description (shortened) or "Enter a value"
+- **Default value**: if `variable.default_value` is provided, pre-filled in the input
+- **Input type**: always `text` in this release (no typed fields)
+
+### Inline Summary
+
+Same component as used in Step 2 when template has no variables:
+
+```
+You are about to create:
+[org] / [name]    Template: [template]    [Type badge]    [Visibility badge]
+```
+
+### States
+
+- **Incomplete** (some required variables empty): Create button disabled
+- **Complete** (all required variables have values): Create button enabled
+- **Submitting** (Create clicked): creation overlay shown; wizard hidden behind overlay
+
+### Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| Variable field | Type | Value captured; Create button re-evaluates enabled state |
+| "← Back" button | Click | Return to Step 2; all Step 2 field values preserved |
+| "Create Repository" button | Click | All required fields validated → creation overlay shows → POST to API |
+
+### Create button activation rules
+
+The Create button is **enabled** when:
+
+- All `required: true` variables have a non-empty value
+- (Step 2 conditions still met — validated before proceeding to Step 3)
+
+---
+
+## Creation Overlay
+
+Displayed over the entire wizard while `POST /api/v1/repositories` is in flight.
+
+### Layout
+
+- Full wizard area covered with a semi-transparent overlay
+- Centred spinner (animated)
+- Heading: "Creating your repository…"
+- Sub-message: "This may take up to a minute. Please don't close this page."
+- No buttons (intentional — creation cannot be cancelled mid-flight)
+
+### Behaviour
+
+- Activated immediately when the user clicks "Create Repository"
+- Wizard step content is visually obscured (not removed from DOM — allows error recovery)
+- If the API call succeeds: navigates to `/create/success`
+- If the API call fails: overlay is dismissed; appropriate inline error is shown (see below)
+
+---
+
+## Creation Error States
+
+All creation errors are shown as an `InlineAlert` component with `variant="error"` above the
+Create button (Step 2 or Step 3 depending on where creation was triggered). The creation overlay
+is dismissed before the error appears.
+
+| API Error | Recovery UX |
+|---|---|
+| 422 — name already taken (race condition) | User returned to Step 2; name field shows taken error; InlineAlert: "A repository named '[name]' was created while you were filling in this form. Please choose a different name." |
+| 422 — template not found | User returned to Step 1; template grid reloaded; InlineAlert: "The template '[name]' is no longer available. Please choose a different template." |
+| 403 — permission denied | InlineAlert in current step: "You don't have permission to create repositories in this organization. Contact your administrator." |
+| 5xx — GitHub API error | InlineAlert in current step: "GitHub is temporarily unavailable. Your repository was not created. Please try again." |
+| Network error (no response) | InlineAlert in current step: "Could not reach the server. Check your connection and try again." |
+
+---
+
+## Accessibility
+
+- Wizard is a single `<form>` element; Create triggers form submission
+- Step heading is an `<h1>` that updates as steps advance
+- Step progress indicator has `aria-label="Step [n] of [total]"`
+- Template card grid: each card is a `<label>` wrapping a radio `<input>` for screen reader support
+- All form fields have explicit `<label>` associations
+- Required fields use `aria-required="true"` in addition to the visual asterisk
+- Validation error messages use `role="alert"` (announced on appearance)
+- InlineAlert errors use `role="alert"`
+- Spinner in creation overlay has `role="status"` and `aria-label="Creating repository"`
+- Tab order follows visual reading order (top to bottom)
+- Minimum touch target: 44×44px for all interactive elements
+- Focus management: when advancing to a new step, focus moves to the step's `<h1>`
+
+---
+
+## Data Requirements
+
+### API calls made by this screen
+
+| Call | When | Endpoint |
+|---|---|---|
+| Fetch template list | On step entry (page load) | `GET /api/v1/orgs/{org}/templates` |
+| Fetch template details | When user selects a template card | `GET /api/v1/orgs/{org}/templates/{template}` |
+| Fetch repository types | On step 2 entry (first time only) | `GET /api/v1/orgs/{org}/repository-types` |
+| Validate name uniqueness | On blur of name field (if format valid) | `POST /api/v1/repositories/validate-name` |
+| Create repository | On "Create Repository" click | `POST /api/v1/repositories` |
+
+### Inputs collected (final POST body)
+
+```json
+{
+  "organization": "<configured org>",
+  "name": "<user input>",
+  "template": "<selected template name>",
+  "visibility": "<"private"|"public">",
+  "team": "<selected team name or omitted>",
+  "repository_type": "<selected type name or omitted>",
+  "variables": {
+    "<var_name>": "<user value>",
+    ...
+  }
+}
+```

--- a/docs/spec/ux/screens/SCR-005-repository-created.md
+++ b/docs/spec/ux/screens/SCR-005-repository-created.md
@@ -1,0 +1,147 @@
+# SCR-005: Repository Created
+
+**Route**: `/create/success`
+**Goal served**: Confirm that the repository was created and give the user a direct link to it
+**Entry points**: Redirect from `/create` after successful `POST /api/v1/repositories`
+**Exit points**: GitHub repository URL (external, new tab); `/create` (create another)
+
+---
+
+## Wireframe
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|                         ✓                                    |
+|                    (success icon)                            |
+|                                                              |
+|                   Repository created!                        |
+|                                                              |
+|               myorg/my-new-service                           |
+|   https://github.com/myorg/my-new-service (clickable link)   |
+|                                                              |
+|  +----------------------------------------------------------+|
+|  |           View repository on GitHub ↗                   ||
+|  +----------------------------------------------------------+|
+|                                                              |
+|             [ Create another repository ]                    |
+|                                                              |
+|  ▸ What was applied                                          |
+|    (collapsed; click to expand applied config summary)       |
+|                                                              |
++==============================================================+
+```
+
+Expanded "What was applied" section:
+
+```
+|  ▾ What was applied                                          |
+|  +----------------------------------------------------------+|
+|  | Template: rust-library                                  ||
+|  | Repository type: library                                ||
+|  | Team: platform                                          ||
+|  | Visibility: private                                     ||
+|  | Created: 2026-03-24 14:32:07 UTC                        ||
+|  +----------------------------------------------------------+|
+```
+
+---
+
+## Purpose
+
+Clearly confirm success and make it trivially easy to open the new repository. Provide a
+"Create another repository" action so users who need to create several repositories in sequence
+do not have to re-navigate.
+
+The route carries the created repository's full name as a query parameter so the page can
+display correct details even on a page refresh.
+
+**Route**: `/create/success?repo={org}/{name}`
+
+---
+
+## Layout
+
+- AppShell (header with logo + UserBadge)
+- Centred content area, single column
+- Large success icon (checkmark) above the heading
+- Repository name prominently displayed
+- Two action buttons: "View repository on GitHub" (primary, opens new tab) + "Create another repository" (secondary)
+- Applied configuration summary (collapsed by default, expandable)
+
+---
+
+## States
+
+### Success (query parameter present and valid)
+
+- Success icon: visible
+- Heading: "Repository created!"
+- Repository full name: "[org]/[name]" displayed in monospace/code style
+- Repository URL as a clickable link beneath the full name
+- "View repository on GitHub" button: opens new tab to the GitHub URL
+- "Create another repository" button: navigates to `/create` (resets the wizard)
+- Applied configuration summary: collapsed section titled "What was applied", showing:
+  - Template used
+  - Repository type (if set)
+  - Team (if set)
+  - Visibility
+  - Creation timestamp
+
+### Invalid / missing query parameter
+
+If the user navigates to `/create/success` directly without the `repo` parameter, or the parameter
+is malformed:
+
+- No success icon or repository name shown
+- Info message: "Your repository was created. Check your GitHub organization to find it."
+- "Create another repository" button: visible
+
+---
+
+## Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| "View repository on GitHub" button | Click | Opens GitHub repository URL in a new tab |
+| Repository URL link | Click | Opens GitHub repository URL in a new tab |
+| "Create another repository" button | Click | Navigate to `/create`; wizard resets to Step 1 |
+| Applied config summary toggle | Click | Expands/collapses the applied configuration section |
+
+---
+
+## Accessibility
+
+- `<h1>`: "Repository created!"
+- Success icon has `aria-hidden="true"` (decorative)
+- Repository name and link have clear label context
+- Applied config summary uses `<details>` / `<summary>` for semantic expand/collapse
+- "View repository on GitHub" button has `aria-label="View [org/name] on GitHub"` to give screen
+  readers the repository name in context; also has `target="_blank"` with `rel="noopener"`
+  and a visible "(opens in new tab)" indicator
+
+---
+
+## Copy
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Repository created — RepoRoller |
+| Heading `<h1>` | Repository created! |
+| Repository link label | View on GitHub |
+| "View on GitHub" button | View repository on GitHub |
+| "Create another" button | Create another repository |
+| Applied config summary label | What was applied |
+| Invalid state message | Your repository was created. Check your GitHub organization to find it. |
+
+---
+
+## Data Requirements
+
+- **Inputs**: `repo` query parameter (format: `{org}/{name}`) + full creation response stored in
+  session/navigation state from the creation redirect
+- **No additional API calls** on this screen
+- The applied configuration details come from the `CreateRepositoryResponse.configuration`
+  returned by the creation API call, passed via navigation state (not re-fetched)

--- a/docs/spec/ux/screens/SCR-005-repository-created.md
+++ b/docs/spec/ux/screens/SCR-005-repository-created.md
@@ -119,7 +119,7 @@ is malformed:
 - Repository name and link have clear label context
 - Applied config summary uses `<details>` / `<summary>` for semantic expand/collapse
 - "View repository on GitHub" button has `aria-label="View [org/name] on GitHub"` to give screen
-  readers the repository name in context; also has `target="_blank"` with `rel="noopener"`
+  readers the repository name in context; also has `target="_blank"` with `rel="noopener noreferrer"`
   and a visible "(opens in new tab)" indicator
 
 ---
@@ -128,7 +128,7 @@ is malformed:
 
 | Element | Copy |
 |---|---|
-| Page `<title>` | Repository created — RepoRoller |
+| Page `<title>` | Repository created — [App Name] |
 | Heading `<h1>` | Repository created! |
 | Repository link label | View on GitHub |
 | "View on GitHub" button | View repository on GitHub |
@@ -140,8 +140,21 @@ is malformed:
 
 ## Data Requirements
 
-- **Inputs**: `repo` query parameter (format: `{org}/{name}`) + full creation response stored in
-  session/navigation state from the creation redirect
+- **Inputs**: `repo` query parameter (format: `{org}/{name}`) + creation response and wizard
+  inputs stored in navigation state from the creation redirect
 - **No additional API calls** on this screen
-- The applied configuration details come from the `CreateRepositoryResponse.configuration`
-  returned by the creation API call, passed via navigation state (not re-fetched)
+- **Data sources for the "What was applied" section**:
+
+  | Field shown | Source |
+  |---|---|
+  | Repository full name, URL | `CreateRepositoryResponse.repository.full_name`, `.url` |
+  | Visibility | `CreateRepositoryResponse.repository.visibility` |
+  | Repository type | `CreateRepositoryResponse.repository.repository_type` (optional) |
+  | Creation timestamp | `CreateRepositoryResponse.repository.created_at` |
+  | Template name | Wizard navigation state (captured at step 1; not present in API response) |
+  | Team name | Wizard navigation state (captured at step 2; not present in API response) |
+
+  **Note**: `AppliedConfiguration.applied_settings` is internal configuration metadata (branch
+  protection rules, repository settings, etc.) and is not surfaced directly in this UI. Template
+  name and team name must be carried in navigation state from the wizard, as `RepositoryInfo`
+  does not include them.

--- a/docs/spec/ux/screens/SCR-006-error.md
+++ b/docs/spec/ux/screens/SCR-006-error.md
@@ -111,7 +111,7 @@ that is not possible.
 
 | Element | Copy |
 |---|---|
-| Page `<title>` | Error — RepoRoller |
+| Page `<title>` | Error — [App Name] |
 | Generic heading | Something went wrong |
 | Generic message | An unexpected error occurred. If this keeps happening, contact your platform team. |
 | Generic button | Try again |

--- a/docs/spec/ux/screens/SCR-006-error.md
+++ b/docs/spec/ux/screens/SCR-006-error.md
@@ -1,0 +1,128 @@
+# SCR-006: Error
+
+**Route**: `/error`
+**Goal served**: Handle unexpected system errors that cannot be recovered inline
+**Entry points**: Any screen when an unrecoverable error occurs; server-side redirect on catastrophic failure
+**Exit points**: `/create` (try again); `/sign-in` (if session may have been involved)
+
+---
+
+## Wireframe
+
+**Generic error variant:**
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                   [ @username v ]      |
++==============================================================+
+|                                                              |
+|                         ⚠                                    |
+|                    (warning icon)                            |
+|                                                              |
+|                  Something went wrong                        |
+|                                                              |
+|  An unexpected error occurred. If this keeps happening,      |
+|  contact your platform team.                                 |
+|                                                              |
+|  +----------------------------------------------------------+|
+|  |                   Try again                             ||
+|  +----------------------------------------------------------+|
+|                                                              |
++==============================================================+
+```
+
+**Session expired variant** (header may show minimal branding only, no UserBadge):
+
+```
++==============================================================+
+|  [ Logo ]  [App Name]                                        |
++==============================================================+
+|                                                              |
+|                         🔒                                   |
+|                    (lock icon)                               |
+|                                                              |
+|               Your session has expired                       |
+|                                                              |
+|  Please sign in again to continue.                           |
+|                                                              |
+|  +----------------------------------------------------------+|
+|  |                    Sign in                              ||
+|  +----------------------------------------------------------+|
+|                                                              |
++==============================================================+
+```
+
+---
+
+## Purpose
+
+A fallback screen for failures that cannot be shown inline (e.g., a server-side rendering error,
+failed middleware, or an error that occurs before a specific screen's error handling can run).
+
+Most errors are handled inline on the screen where they occur. This screen is only reached when
+that is not possible.
+
+---
+
+## Layout
+
+- AppShell (header displayed if session available; minimal header if not)
+- Centred content area, single column
+- Warning/error icon
+- Heading
+- Explanatory message
+- Action button(s)
+
+---
+
+## States
+
+### Generic error (default — no `reason` parameter or unknown reason)
+
+- Heading: "Something went wrong"
+- Message: "An unexpected error occurred. If this keeps happening, contact your platform team."
+- Button: "Try again" → `/create` (or `/sign-in` if no session)
+
+### Session expired (reason=session_expired — future use)
+
+- Heading: "Your session has expired"
+- Message: "Please sign in again to continue."
+- Button: "Sign in" → `/sign-in`
+
+---
+
+## Interactions
+
+| Element | Action | Outcome |
+|---|---|---|
+| "Try again" button | Click | Navigate to `/create` if session exists, otherwise `/sign-in` |
+| "Sign in" button (session_expired state) | Click | Navigate to `/sign-in` |
+
+---
+
+## Accessibility
+
+- `<h1>` matches the state heading
+- Error message uses `role="alert"` (announced on page load to screen readers)
+
+---
+
+## Copy
+
+| Element | Copy |
+|---|---|
+| Page `<title>` | Error — RepoRoller |
+| Generic heading | Something went wrong |
+| Generic message | An unexpected error occurred. If this keeps happening, contact your platform team. |
+| Generic button | Try again |
+| Session expired heading | Your session has expired |
+| Session expired message | Please sign in again to continue. |
+| Session expired button | Sign in |
+
+---
+
+## Data Requirements
+
+- **Inputs**: `reason` query parameter (optional; values: `session_expired`)
+- **No async data loading**
+- **Security**: No internal error details, stack traces, or identifiers surfaced to the client

--- a/docs/spec/ux/user-goals.md
+++ b/docs/spec/ux/user-goals.md
@@ -1,0 +1,44 @@
+# User Goals
+
+## Primary Users
+
+RepoRoller is a self-service tool for all members of a GitHub organization. All users share the
+same role and the same capabilities — there is no admin tier in the web UI at this stage.
+
+### User Types
+
+**Active org member**
+A developer, platform engineer, or other team member who belongs to the organization and needs to
+create a new GitHub repository. Has access to the VPN. May or may not have used RepoRoller before.
+
+**First-time user**
+Same as above, but has never authenticated with the web UI. Must complete the sign-in flow before
+reaching the creation form.
+
+**Returning user**
+Has a valid session from a previous visit. Arrives directly at the creation form.
+
+---
+
+## Goals by User Type
+
+| User | Goal | Success Condition |
+|---|---|---|
+| First-time user | Sign in and create a repository | Repository exists on GitHub, creator's username in audit log, total time under 5 minutes |
+| First-time user | Understand what templates are available before committing | Can browse templates in the creation wizard before finalising their choice |
+| Returning user | Create a repository quickly | Arrives at the form immediately, no re-authentication required |
+| Any user | Know whether their chosen repository name is valid and available | Real-time feedback while typing, before form submission |
+| Any user | Understand what each template will produce | Template card shows enough context (description, type, tags) to make an informed choice |
+| Any user | Understand what template variables are and what to enter | Each variable shows a description and, where applicable, a default value |
+| Any user | Know the outcome of their creation request | Success: sees repository link. Failure: sees what went wrong and what to do next |
+
+---
+
+## Non-Goals (explicitly out of scope for this release)
+
+- Browsing templates without creating a repository (no standalone template catalogue)
+- Viewing or editing existing repository settings
+- Managing organization configuration (templates, types, global defaults)
+- Creating repositories in multiple organizations from one UI
+- Admin functionality (validating org config, managing teams)
+- Batch repository creation

--- a/docs/spec/ux/ux-assertions.md
+++ b/docs/spec/ux/ux-assertions.md
@@ -84,7 +84,7 @@ Each assertion follows Given / When / Then structure.
 
 - **Given**: The user has entered a correctly-formatted repository name
 - **When**: The name field loses focus (blur event)
-- **Then**: A `POST /repositories/validate-name` API call is made
+- **Then**: A `POST /api/v1/repositories/validate-name` API call is made
 - **And**: The field shows a "Checking availability…" indicator during the call
 
 ### UX-ASSERT-011: Next / Create button is disabled while uniqueness check is in-flight
@@ -99,6 +99,14 @@ Each assertion follows Given / When / Then structure.
 - **When**: The result is shown to the user
 - **Then**: The name field shows an "already taken" error
 - **And**: The Next / Create button remains disabled until the name is changed
+
+### UX-ASSERT-028: Next / Create button is enabled when the uniqueness check could not be completed
+
+- **Given**: The uniqueness check API call fails (network error or server error)
+- **When**: The `check_failed` result is shown below the name field
+- **Then**: The Next / Create button is **enabled** (not disabled)
+- **And**: A warning indicator below the field advises the user that availability could not be confirmed
+- **And**: The user can proceed with the understanding that the name may already exist (a race-condition 422 on creation will handle the conflict)
 
 ### UX-ASSERT-013: Changing the name after a "taken" result clears the error immediately
 

--- a/docs/spec/ux/ux-assertions.md
+++ b/docs/spec/ux/ux-assertions.md
@@ -1,0 +1,233 @@
+# UX Assertions
+
+Testable behavioural specifications for the RepoRoller web UI. These assertions are inputs for
+the Tester to generate UI test specifications.
+
+Each assertion follows Given / When / Then structure.
+
+---
+
+## Authentication
+
+### UX-ASSERT-001: Unauthenticated users cannot access protected routes
+
+- **Given**: A user has no active session
+- **When**: They navigate to `/create`
+- **Then**: They are redirected to `/sign-in`
+- **And**: No content from `/create` is visible before the redirect
+
+### UX-ASSERT-002: GitHub identity is captured from OAuth, not user input
+
+- **Given**: A user completes the GitHub OAuth flow
+- **When**: Their session is created
+- **Then**: Their GitHub login is stored as the authenticated identity
+- **And**: There is no form field on any screen where the user can supply or override their username
+
+### UX-ASSERT-003: OAuth denial navigates to Access Denied, not Sign In
+
+- **Given**: A user clicks "Authorize" and then "Cancel" on the GitHub authorization page
+- **When**: GitHub redirects back to `/auth/callback` with `error=access_denied`
+- **Then**: The user is shown the Access Denied screen (SCR-003) with the `access_denied` reason copy
+- **And**: The user is NOT shown the Sign In screen directly
+
+### UX-ASSERT-004: Sign-out destroys session and returns to sign-in
+
+- **Given**: A user is authenticated and on any page with the AppShell
+- **When**: They click "Sign out" in the UserBadge dropdown
+- **Then**: Their session is destroyed
+- **And**: They are redirected to `/sign-in`
+- **And**: Navigating back to `/create` requires re-authentication
+
+---
+
+## Step 1: Template Selection
+
+### UX-ASSERT-005: Next button is disabled until a template is selected
+
+- **Given**: The user is on Step 1 of the creation wizard
+- **When**: No template card has been selected
+- **Then**: The "Next: Repository settings" button is disabled
+
+### UX-ASSERT-006: Template details are fetched on card selection, not on Next click
+
+- **Given**: The user clicks a template card in Step 1
+- **When**: The selection is registered
+- **Then**: A `GET /orgs/{org}/templates/{template}` request is immediately initiated
+- **And**: The Next button is not enabled until the details fetch completes successfully
+
+### UX-ASSERT-007: Returning to Step 1 from Step 2 preserves the selected template
+
+- **Given**: The user has selected a template in Step 1 and advanced to Step 2
+- **When**: They click "← Back"
+- **Then**: The previously selected template card is still shown as selected in Step 1
+
+### UX-ASSERT-008: Template list API failure shows an error state with retry
+
+- **Given**: The template list API call fails
+- **When**: The Step 1 view renders
+- **Then**: An error message is shown with a "Try again" button
+- **And**: No template cards are shown
+- **And**: The Next button remains disabled
+
+---
+
+## Step 2: Repository Settings
+
+### UX-ASSERT-009: Repository name format is validated client-side on type
+
+- **Given**: The user is typing in the repository name field
+- **When**: The name contains characters not matching the GitHub name format (e.g., uppercase, spaces, special characters)
+- **Then**: An inline error message appears below the field describing the format constraint
+- **And**: No API call is made for uniqueness checking
+
+### UX-ASSERT-010: Uniqueness check fires on blur, not on type
+
+- **Given**: The user has entered a correctly-formatted repository name
+- **When**: The name field loses focus (blur event)
+- **Then**: A `POST /repositories/validate-name` API call is made
+- **And**: The field shows a "Checking availability…" indicator during the call
+
+### UX-ASSERT-011: Next / Create button is disabled while uniqueness check is in-flight
+
+- **Given**: A uniqueness check API call is in progress
+- **When**: The user attempts to click the Next or Create button
+- **Then**: The button is disabled and the click has no effect
+
+### UX-ASSERT-012: Next / Create button is disabled when name is already taken
+
+- **Given**: The uniqueness check API returns that the name is already taken
+- **When**: The result is shown to the user
+- **Then**: The name field shows an "already taken" error
+- **And**: The Next / Create button remains disabled until the name is changed
+
+### UX-ASSERT-013: Changing the name after a "taken" result clears the error immediately
+
+- **Given**: The name field shows an "already taken" error
+- **When**: The user changes the value in the name field (any keystroke)
+- **Then**: The "already taken" error is immediately cleared (without waiting for blur)
+
+### UX-ASSERT-014: Step 2 values are preserved when returning from Step 3
+
+- **Given**: The user has advanced from Step 2 to Step 3 with a valid name and other settings
+- **When**: They click "← Back" from Step 3
+- **Then**: The repository name, type, team, and visibility fields in Step 2 still show the values they entered
+- **And**: No additional API calls are made (uniqueness is not re-checked on step return)
+
+---
+
+## Step 3: Template Variables
+
+### UX-ASSERT-015: Step 3 is skipped when the template has no variables
+
+- **Given**: The user selects a template that defines no template variables
+- **When**: They complete Step 2 with a valid repository name
+- **Then**: The "Create Repository" button appears in Step 2 (not a "Next: Variables" button)
+- **And**: No Step 3 is shown; clicking Create initiates the creation directly
+
+### UX-ASSERT-016: Create button disabled until all required variables are filled
+
+- **Given**: The user is on Step 3 with at least one required variable
+- **When**: Any required variable field is empty
+- **Then**: The "Create Repository" button is disabled
+
+### UX-ASSERT-017: Optional variables with defaults are pre-filled
+
+- **Given**: The selected template has a variable with a `default_value`
+- **When**: Step 3 renders
+- **Then**: The corresponding field shows the default value pre-populated
+- **And**: The user can change it
+
+---
+
+## Creation Submission
+
+### UX-ASSERT-018: Double submission is prevented
+
+- **Given**: The user clicks "Create Repository"
+- **When**: The creation API call is in flight
+- **Then**: The creation overlay is shown
+- **And**: The wizard buttons are not accessible
+- **And**: A second API call cannot be initiated
+
+### UX-ASSERT-019: Race-condition name conflict returns user to Step 2
+
+- **Given**: The user submits a valid creation request
+- **When**: The API returns 422 with a "name already taken" error (race condition)
+- **Then**: The creation overlay is dismissed
+- **And**: The user is returned to Step 2
+- **And**: The name field shows an "already taken" error
+- **And**: An InlineAlert explains What happened above the name field
+
+### UX-ASSERT-020: Template-not-found error during creation returns user to Step 1
+
+- **Given**: The user submits a valid creation request
+- **When**: The API returns 422 with a "template not found" error
+- **Then**: The creation overlay is dismissed
+- **And**: The user is returned to Step 1
+- **And**: The template list is refreshed
+- **And**: An InlineAlert explains that the template is no longer available
+
+### UX-ASSERT-021: GitHub API errors are shown inline without losing form data
+
+- **Given**: The user submits a creation request
+- **When**: The API returns a 5xx error
+- **Then**: The creation overlay is dismissed
+- **And**: An InlineAlert with the error message is shown on the current step
+- **And**: All form data (name, template selection, variables) is still present
+- **And**: The user can retry without re-entering data
+
+---
+
+## Success Screen
+
+### UX-ASSERT-022: Success screen shows the correct repository name and link
+
+- **Given**: Repository creation succeeds
+- **When**: The user is redirected to `/create/success`
+- **Then**: The full repository name (`{org}/{name}`) is displayed
+- **And**: A link to the GitHub repository URL is present and correct
+
+### UX-ASSERT-023: "Create another" navigates to a reset wizard
+
+- **Given**: The user is on the Repository Created screen
+- **When**: They click "Create another repository"
+- **Then**: They are navigated to `/create`
+- **And**: The wizard starts at Step 1 with no template selected and all fields empty
+
+---
+
+## Accessibility
+
+### UX-ASSERT-024: Keyboard-only navigation works through the complete creation wizard
+
+- **Given**: A user navigates using Tab and Enter/Space only
+- **When**: Interacting with the creation wizard from Step 1 through to clicking Create
+- **Then**: All interactive elements (template cards, form fields, buttons) are reachable
+- **And**: Tab order follows the documented reading order (top to bottom)
+- **And**: Focus moves to the step `<h1>` heading when advancing to a new step
+
+### UX-ASSERT-025: Error messages are announced to screen readers
+
+- **Given**: A validation error or API error appears on any form field or as an InlineAlert
+- **When**: The error is rendered
+- **Then**: The error message uses `role="alert"` and is announced by screen readers without requiring user focus movement
+
+---
+
+## Branding
+
+### UX-ASSERT-026: Logo image falls back to text wordmark when not configured
+
+- **Given**: `brand.logo_url` is not set in the deployment branding configuration
+- **When**: Any screen with the logo area renders (AppShell header or BrandCard)
+- **Then**: The app name text is shown as a styled text wordmark
+- **And**: No broken image icon appears
+- **And**: The layout does not shift or collapse
+
+### UX-ASSERT-027: Primary colour applies consistently to all interactive elements
+
+- **Given**: A custom `brand.primary_color` is configured at deployment
+- **When**: Any interactive element renders — primary buttons, selected template card borders,
+  step progress indicators, links, focus rings
+- **Then**: Each element uses the configured colour
+- **And**: No interactive element uses the default blue (`#0969da`) when a custom colour is set


### PR DESCRIPTION
Adds a complete UX specification for the SvelteKit web UI, covering authentication, repository creation, and branding. Intended as the design contract for the interface designer and coder to implement against.

references #12

## What Changed
- 17 new files added under `docs/spec/ux/` and `docs/adr/`
- 6 screen specifications (sign-in, OAuth callback, access denied, create-repository wizard, success, error), each with ASCII wireframes, interaction tables, state inventories, copy, and accessibility requirements
- 2 user flow diagrams in Mermaid (authentication, repository creation) covering all happy-path and error branches
- 12 component contracts with typed prop and event definitions (entry point for the interface designer)
- 27 testable UX assertions in Given/When/Then format
- Navigation map, consolidated copy reference, and branding specification
- ADR-0008: deployment-time white-labelling via `brand.toml` / environment variables; indexed in `docs/adr/README.md`

## Why
Task 13.0 requires a SvelteKit web UI. Before implementation begins, a full UX specification is needed so the interface designer can define typed contracts and the coder has unambiguous interaction targets. No spec existed previously.

## How
Three design decisions drive the structure:
- **GitHub OAuth (Model A)**: identity is verified via GitHub; VPN handles access control; org membership check is deferred but the architecture accommodates it
- **2–3 step creation wizard**: Step 3 (template variables) is skipped entirely when the chosen template has no variables, avoiding an unnecessary screen transition
- **Branding**: four configurable tokens (`app_name`, `logo_url`, `logo_alt`, `primary_color`) loaded at server startup; propagated as `--brand-primary` CSS custom property; documented in ADR-0008

## Testing Evidence
- **Test Coverage:** 27 UX assertions in `docs/spec/ux/ux-assertions.md` are structured for direct use as UI test specifications by the tester mode
- **Test Results:** No code changes — documentation only; existing test suite unaffected
- **Manual Testing:** All screen specs, flows, and component contracts reviewed for internal consistency; cross-references between files verified

## Reviewer Guidance
- Start at `docs/spec/ux/README.md` — it is the index and contains the handoff summary
- Review `docs/spec/ux/ux-assertions.md` against the screen specs to confirm all stated behaviours are actually specified
- Check `docs/spec/ux/components/component-inventory.md` — these contracts are the direct input to the interface designer; prop and event names should look reasonable before implementation begins
- `docs/adr/ADR-0008-web-ui-branding.md` records the decision to use deployment-time branding over build-time baking; worth confirming the alternatives were the right ones to reject
- No production code changed; no breaking changes; no migration steps required