### PR TITLE
feat(api): wire real-time GitHub name availability check into validate-name endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,6 +2634,7 @@ dependencies = [
  "github_client",
  "http-body-util",
  "hyper 1.7.0",
+ "octocrab",
  "prometheus",
  "repo_roller_core",
  "serde",
@@ -2646,6 +2647,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock 0.6.5",
 ]
 
 [[package]]

--- a/crates/github_client/src/lib.rs
+++ b/crates/github_client/src/lib.rs
@@ -3720,6 +3720,33 @@ pub fn create_token_client(token: &str) -> Result<Octocrab, Error> {
         .map_err(|_| Error::ApiError())
 }
 
+/// Creates a [`GitHubClient`] from a personal access token.
+///
+/// The optional `base_url` parameter overrides the default GitHub API base URL
+/// (`https://api.github.com`). Pass a value when targeting a GitHub Enterprise
+/// instance or a mock server in tests.
+///
+/// # Errors
+///
+/// Returns [`Error::ApiError`] if the Octocrab client cannot be built (for
+/// example, when `base_url` is syntactically invalid).
+pub fn create_github_client(token: &str, base_url: Option<&str>) -> Result<GitHubClient, Error> {
+    let octocrab = if let Some(url) = base_url {
+        Octocrab::builder()
+            .personal_token(token.to_string())
+            .base_uri(url)
+            .map_err(|_| Error::ApiError())?
+            .build()
+            .map_err(|_| Error::ApiError())?
+    } else {
+        Octocrab::builder()
+            .personal_token(token.to_string())
+            .build()
+            .map_err(|_| Error::ApiError())?
+    };
+    Ok(GitHubClient::new(octocrab))
+}
+
 /// Helper function to log Octocrab errors with appropriate detail.
 ///
 /// This function examines the type of Octocrab error and logs relevant

--- a/crates/integration_tests/tests/cli_template_commands_tests.rs
+++ b/crates/integration_tests/tests/cli_template_commands_tests.rs
@@ -252,8 +252,7 @@ async fn test_validate_invalid_template() -> Result<()> {
     // Use template-test-invalid if it exists, or expect validation issues
     let result = validate_template(&test_config.test_org, "template-test-invalid", provider).await;
 
-    if result.is_ok() {
-        let validation = result.unwrap();
+    if let Ok(validation) = result {
         // If template exists but is invalid, validation should detect issues
         if validation.template_name == "template-test-invalid" {
             // Either not valid or has warnings

--- a/crates/repo_roller_api/Cargo.toml
+++ b/crates/repo_roller_api/Cargo.toml
@@ -48,6 +48,8 @@ uuid.workspace = true
 http-body-util = "=0.1.3"
 tower = { workspace = true, features = ["util"] }
 hyper = { workspace = true, features = ["full"] }
+octocrab.workspace = true
+wiremock = "=0.6.5"
 
 [[bin]]
 name = "repo_roller_api"

--- a/crates/repo_roller_api/src/handlers.rs
+++ b/crates/repo_roller_api/src/handlers.rs
@@ -269,22 +269,69 @@ pub(crate) async fn check_org_naming_rules(
     }
 }
 
+/// Check whether a repository name is available in the given organisation by
+/// querying the GitHub API.
+///
+/// This is a best-effort check: API failures degrade gracefully — the caller
+/// still learns `available = true` (warn-only, no 5xx).
+///
+/// # Returns
+///
+/// A tuple of `(available, optional_warning_message)`.  When the repository
+/// exists the first element is `false`; when the check could not be completed
+/// due to an API error the first element is `true` and the second contains a
+/// human-readable warning.
+pub(crate) async fn check_repository_availability(
+    client: &GitHubClient,
+    org: &str,
+    name: &str,
+) -> (bool, Option<String>) {
+    match client.get_repository(org, name).await {
+        Ok(_) => (
+            false,
+            Some(format!(
+                "Repository '{name}' already exists in organisation '{org}'."
+            )),
+        ),
+        Err(github_client::Error::NotFound) => (true, None),
+        Err(e) => {
+            tracing::warn!(
+                org = org,
+                name = name,
+                error = ?e,
+                "GitHub API error while checking repository availability; treating as available"
+            );
+            (
+                true,
+                Some(
+                    "Could not verify name availability with GitHub. \
+                     The name may already exist."
+                        .to_string(),
+                ),
+            )
+        }
+    }
+}
+
 /// POST /api/v1/repositories/validate-name
 ///
 /// Validate a repository name for availability and format.
 ///
-/// Performs two levels of validation:
+/// Performs three levels of validation:
 /// 1. **Format check** (always): GitHub character-set rules.
 /// 2. **Org naming rules** (when authenticated): organisation-level constraints
 ///    loaded from the metadata repository via `RepositoryNamingValidator`.
+/// 3. **GitHub availability check** (when format is valid): calls the GitHub
+///    API to verify the name is not already taken in the organisation.
 ///
-/// Org rule loading degrades gracefully — if the metadata repository cannot be
-/// reached the response falls back to the format check alone.
+/// Org rule loading and the GitHub availability check both degrade gracefully —
+/// if either cannot be reached the response falls back to the checks that did
+/// succeed.
 ///
 /// See: specs/interfaces/api-request-types.md#validaterepositorynamerequest
 pub async fn validate_repository_name(
     State(state): State<AppState>,
-    auth: Option<Extension<AuthContext>>,
+    Extension(auth): Extension<AuthContext>,
     Json(request): Json<ValidateRepositoryNameRequest>,
 ) -> Result<Json<ValidateRepositoryNameResponse>, ApiError> {
     let mut messages = Vec::new();
@@ -310,39 +357,70 @@ pub async fn validate_repository_name(
         }
     }
 
-    // When the format is valid and the request is authenticated, also check
-    // organisation-level naming rules loaded from the metadata repository.
-    if valid {
-        if let Some(Extension(auth_ctx)) = auth {
-            match create_settings_manager(&auth_ctx, &state).await {
-                Ok((_manager, provider)) => {
-                    let naming_messages = check_org_naming_rules(
-                        &request.name,
-                        &request.organization,
-                        provider.as_ref(),
-                    )
+    // Format is a hard gate: invalid names never need a GitHub round-trip.
+    if !valid {
+        return Ok(Json(ValidateRepositoryNameResponse {
+            valid: false,
+            available: false,
+            messages: Some(messages),
+        }));
+    }
+
+    // Apply organisation-level naming rules loaded from the metadata repository.
+    match create_settings_manager(&auth, &state).await {
+        Ok((_manager, provider)) => {
+            let naming_messages =
+                check_org_naming_rules(&request.name, &request.organization, provider.as_ref())
                     .await;
-                    if !naming_messages.is_empty() {
-                        valid = false;
-                        messages.extend(naming_messages);
-                    }
-                }
-                Err(e) => {
-                    // Log the failure but do not surface it as an HTTP error — the
-                    // caller still receives a format-only result rather than a 5xx.
-                    tracing::warn!(
-                        org = %request.organization,
-                        error = ?e,
-                        "Failed to create settings manager for naming rule check; skipping org rules"
-                    );
-                }
+            if !naming_messages.is_empty() {
+                valid = false;
+                messages.extend(naming_messages);
             }
+        }
+        Err(e) => {
+            // Log the failure but do not surface it as an HTTP error — the
+            // caller still receives a format-only result rather than a 5xx.
+            tracing::warn!(
+                org = %request.organization,
+                error = ?e,
+                "Failed to create settings manager for naming rule check; skipping org rules"
+            );
         }
     }
 
-    // Repository availability checking via GitHub API is a future enhancement.
-    // See Task 9.7 - REST API Post-MVP Enhancements.
-    let available = valid;
+    // Check real-time GitHub availability (soft-fail on API error).
+    let available = if valid {
+        match github_client::create_token_client(&auth.token) {
+            Ok(octocrab) => {
+                let github_client = GitHubClient::new(octocrab);
+                let (is_available, availability_message) = check_repository_availability(
+                    &github_client,
+                    &request.organization,
+                    &request.name,
+                )
+                .await;
+                if let Some(msg) = availability_message {
+                    messages.push(msg);
+                }
+                is_available
+            }
+            Err(e) => {
+                tracing::warn!(
+                    org = %request.organization,
+                    error = ?e,
+                    "Failed to create GitHub client for availability check; skipping"
+                );
+                messages.push(
+                    "Could not verify name availability with GitHub. \
+                     The name may already exist."
+                        .to_string(),
+                );
+                true
+            }
+        }
+    } else {
+        false
+    };
 
     let response = ValidateRepositoryNameResponse {
         valid,

--- a/crates/repo_roller_api/src/handlers.rs
+++ b/crates/repo_roller_api/src/handlers.rs
@@ -38,23 +38,45 @@ use config_manager::{
 use github_client::GitHubClient;
 use repo_roller_core::{RepoRollerError, RepositoryNamingValidator};
 
+/// Build an `OrganizationSettingsManager` and `MetadataRepositoryProvider` from
+/// an already-constructed `GitHubClient`.
+///
+/// The caller is responsible for constructing the client; this helper wires it
+/// into the metadata provider, template loader, and settings manager.
+///
+/// `client` is cloned once (cheap: shares the underlying connection pool) to
+/// satisfy both the metadata provider and the template repository.
+async fn create_settings_manager_from_client(
+    client: GitHubClient,
+    state: &AppState,
+) -> Result<
+    (
+        OrganizationSettingsManager,
+        Arc<dyn MetadataRepositoryProvider>,
+    ),
+    ApiError,
+> {
+    let provider_config = MetadataProviderConfig::explicit(&state.metadata_repository_name);
+    let metadata_provider = GitHubMetadataProvider::new(client.clone(), provider_config);
+    let provider_arc = Arc::new(metadata_provider) as Arc<dyn MetadataRepositoryProvider>;
+
+    let template_repo = Arc::new(config_manager::GitHubTemplateRepository::new(Arc::new(
+        client,
+    )));
+    let template_loader = Arc::new(config_manager::TemplateLoader::new(template_repo));
+
+    let manager = OrganizationSettingsManager::new(provider_arc.clone(), template_loader);
+    Ok((manager, provider_arc))
+}
+
 /// Create an OrganizationSettingsManager and MetadataRepositoryProvider for a request.
 ///
 /// Creates a GitHub client using the authentication token from the request context,
-/// then creates a metadata provider and settings manager.
-///
-/// # Arguments
-///
-/// * `auth` - Authentication context with bearer token
-/// * `state` - Application state with configuration
-///
-/// # Returns
-///
-/// Returns tuple of (manager, provider) for use in handlers.
+/// then delegates to [`create_settings_manager_from_client`].
 ///
 /// # Errors
 ///
-/// Returns ApiError if GitHub client creation fails.
+/// Returns `ApiError` if GitHub client creation fails.
 async fn create_settings_manager(
     auth: &AuthContext,
     state: &AppState,
@@ -65,28 +87,12 @@ async fn create_settings_manager(
     ),
     ApiError,
 > {
-    // Create GitHub client with installation token
-    let octocrab = github_client::create_token_client(&auth.token)
-        .map_err(|e| ApiError::from(anyhow::anyhow!("Failed to create GitHub client: {}", e)))?;
-
-    let github_client = GitHubClient::new(octocrab.clone());
-
-    // Create metadata provider
-    let provider_config = MetadataProviderConfig::explicit(&state.metadata_repository_name);
-    let metadata_provider = GitHubMetadataProvider::new(github_client, provider_config);
-    let provider_arc = Arc::new(metadata_provider) as Arc<dyn MetadataRepositoryProvider>;
-
-    // Create template loader for template configuration resolution
-    let template_client = GitHubClient::new(octocrab);
-    let template_repo = Arc::new(config_manager::GitHubTemplateRepository::new(Arc::new(
-        template_client,
-    )));
-    let template_loader = Arc::new(config_manager::TemplateLoader::new(template_repo));
-
-    // Create settings manager
-    let manager = OrganizationSettingsManager::new(provider_arc.clone(), template_loader);
-
-    Ok((manager, provider_arc))
+    let client =
+        github_client::create_github_client(&auth.token, state.github_api_base_url.as_deref())
+            .map_err(|e| {
+                ApiError::from(anyhow::anyhow!("Failed to create GitHub client: {}", e))
+            })?;
+    create_settings_manager_from_client(client, state).await
 }
 
 /// Validate a repository name against GitHub naming rules.
@@ -275,6 +281,15 @@ pub(crate) async fn check_org_naming_rules(
 /// This is a best-effort check: API failures degrade gracefully — the caller
 /// still learns `available = true` (warn-only, no 5xx).
 ///
+/// ## Degraded path
+///
+/// Any non-404 error — including `403 Forbidden` (token lacks read access to a
+/// private repository that actually exists) — is treated as a transient failure
+/// and mapped to `available = true` with a warning message. This is intentional
+/// per UX-ASSERT-028: the user may still proceed, but is cautioned that the
+/// check could not be completed. Callers should not infer that a `403` means
+/// the repository is free.
+///
 /// # Returns
 ///
 /// A tuple of `(available, optional_warning_message)`.  When the repository
@@ -318,15 +333,20 @@ pub(crate) async fn check_repository_availability(
 /// Validate a repository name for availability and format.
 ///
 /// Performs three levels of validation:
-/// 1. **Format check** (always): GitHub character-set rules.
-/// 2. **Org naming rules** (when authenticated): organisation-level constraints
-///    loaded from the metadata repository via `RepositoryNamingValidator`.
-/// 3. **GitHub availability check** (when format is valid): calls the GitHub
-///    API to verify the name is not already taken in the organisation.
+/// 1. **Format check** (hard gate, no network): GitHub character-set rules and
+///    empty-value guards for both `name` and `organization`.
+/// 2. **Org naming rules** (soft-fail): organisation-level constraints loaded
+///    from the metadata repository via `RepositoryNamingValidator`.
+/// 3. **GitHub availability check** (soft-fail): calls the GitHub API to verify
+///    the name is not already taken in the organisation.
 ///
-/// Org rule loading and the GitHub availability check both degrade gracefully —
-/// if either cannot be reached the response falls back to the checks that did
-/// succeed.
+/// A single `GitHubClient` is constructed per request and shared between steps
+/// 2 and 3 to avoid redundant HTTP connection-pool creation. The base URL can
+/// be overridden via `AppState::github_api_base_url` (e.g. for GitHub
+/// Enterprise or mock servers in integration tests).
+///
+/// Both network checks degrade gracefully — failures produce warn-only
+/// messages in the response rather than a 5xx.
 ///
 /// See: specs/interfaces/api-request-types.md#validaterepositorynamerequest
 pub async fn validate_repository_name(
@@ -337,27 +357,21 @@ pub async fn validate_repository_name(
     let mut messages = Vec::new();
     let mut valid = true;
 
-    // Check if name is empty.
+    // ── Format validation (hard gate: no network calls) ──────────────────────
     if request.name.is_empty() {
         messages.push("Repository name cannot be empty".to_string());
         valid = false;
     }
-
-    // Check basic GitHub format rules.
     if !is_valid_repository_name(&request.name) {
         messages.push(
             "Repository name can only contain lowercase letters, numbers, hyphens, and underscores"
                 .to_string(),
         );
         valid = false;
-
-        // Provide a specific message for uppercase characters.
         if request.name.chars().any(|c| c.is_uppercase()) {
             messages.push("Repository name cannot contain uppercase letters".to_string());
         }
     }
-
-    // Format is a hard gate: invalid names never need a GitHub round-trip.
     if !valid {
         return Ok(Json(ValidateRepositoryNameResponse {
             valid: false,
@@ -366,8 +380,43 @@ pub async fn validate_repository_name(
         }));
     }
 
-    // Apply organisation-level naming rules loaded from the metadata repository.
-    match create_settings_manager(&auth, &state).await {
+    // ── Organisation validation (hard gate: no network calls) ────────────────
+    if request.organization.is_empty() {
+        return Ok(Json(ValidateRepositoryNameResponse {
+            valid: false,
+            available: false,
+            messages: Some(vec!["Organization name cannot be empty".to_string()]),
+        }));
+    }
+
+    // ── Build a single GitHub client for all subsequent API calls ─────────────
+    // One client is reused for both the org naming-rules check and the
+    // availability check, avoiding redundant HTTP connection-pool creation.
+    // The base URL can be overridden via AppState::github_api_base_url (for
+    // GitHub Enterprise deployments or mock servers in integration tests).
+    let github_client = match github_client::create_github_client(
+        &auth.token,
+        state.github_api_base_url.as_deref(),
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                org = %request.organization,
+                error = ?e,
+                "Failed to create GitHub client; skipping naming rules and availability check"
+            );
+            return Ok(Json(ValidateRepositoryNameResponse {
+                valid: true,
+                available: true,
+                messages: Some(vec!["Could not verify name availability with GitHub. \
+                     The name may already exist."
+                    .to_string()]),
+            }));
+        }
+    };
+
+    // ── Org naming rules (soft-fail) ──────────────────────────────────────────
+    match create_settings_manager_from_client(github_client.clone(), &state).await {
         Ok((_manager, provider)) => {
             let naming_messages =
                 check_org_naming_rules(&request.name, &request.organization, provider.as_ref())
@@ -378,8 +427,6 @@ pub async fn validate_repository_name(
             }
         }
         Err(e) => {
-            // Log the failure but do not surface it as an HTTP error — the
-            // caller still receives a format-only result rather than a 5xx.
             tracing::warn!(
                 org = %request.organization,
                 error = ?e,
@@ -388,41 +435,20 @@ pub async fn validate_repository_name(
         }
     }
 
-    // Check real-time GitHub availability (soft-fail on API error).
+    // ── Real-time name availability check (soft-fail) ─────────────────────────
     let available = if valid {
-        match github_client::create_token_client(&auth.token) {
-            Ok(octocrab) => {
-                let github_client = GitHubClient::new(octocrab);
-                let (is_available, availability_message) = check_repository_availability(
-                    &github_client,
-                    &request.organization,
-                    &request.name,
-                )
+        let (is_available, availability_message) =
+            check_repository_availability(&github_client, &request.organization, &request.name)
                 .await;
-                if let Some(msg) = availability_message {
-                    messages.push(msg);
-                }
-                is_available
-            }
-            Err(e) => {
-                tracing::warn!(
-                    org = %request.organization,
-                    error = ?e,
-                    "Failed to create GitHub client for availability check; skipping"
-                );
-                messages.push(
-                    "Could not verify name availability with GitHub. \
-                     The name may already exist."
-                        .to_string(),
-                );
-                true
-            }
+        if let Some(msg) = availability_message {
+            messages.push(msg);
         }
+        is_available
     } else {
         false
     };
 
-    let response = ValidateRepositoryNameResponse {
+    Ok(Json(ValidateRepositoryNameResponse {
         valid,
         available,
         messages: if messages.is_empty() {
@@ -430,9 +456,7 @@ pub async fn validate_repository_name(
         } else {
             Some(messages)
         },
-    };
-
-    Ok(Json(response))
+    }))
 }
 
 /// POST /api/v1/repositories/validate

--- a/crates/repo_roller_api/src/handlers_tests.rs
+++ b/crates/repo_roller_api/src/handlers_tests.rs
@@ -101,6 +101,22 @@ async fn test_validate_repository_name_valid() {
     assert_eq!(response_json["valid"], true);
     // GitHub call fails with fake token — handler degrades: available=true with a warning message.
     assert_eq!(response_json["available"], true);
+    // A warning message must be present when the GitHub API call fails (degraded path).
+    let msgs = response_json["messages"]
+        .as_array()
+        .expect("messages should be a JSON array in the degraded path");
+    assert!(
+        !msgs.is_empty(),
+        "Expected at least one warning message when GitHub availability check degrades"
+    );
+    assert!(
+        msgs.iter().any(|m| m
+            .as_str()
+            .unwrap_or("")
+            .to_lowercase()
+            .contains("could not verify")),
+        "Warning message should indicate that availability could not be verified"
+    );
 }
 
 /// Test validate_repository_name endpoint with invalid name.
@@ -649,6 +665,139 @@ async fn test_check_repository_availability_api_error_returns_available_with_war
         msg.to_lowercase().contains("could not verify"),
         "Warning should mention that availability could not be verified; got: {msg}"
     );
+}
+
+/// Handler-level test: when the GitHub API confirms the repository already
+/// exists, the handler returns `available=false`.
+///
+/// Uses a wiremock server to avoid real network calls and to control the
+/// response precisely. AppState::with_github_api_base_url() redirects all
+/// GitHub API calls from the handler to the mock server.
+#[tokio::test]
+async fn test_validate_repository_name_returns_available_false_when_repo_exists() {
+    let mock_server = MockServer::start().await;
+
+    // The handler calls GET /repos/{org}/{name} to check existence.
+    Mock::given(method("GET"))
+        .and(path("/repos/testorg/existing-repo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 42,
+            "name": "existing-repo",
+            "full_name": "testorg/existing-repo",
+            "private": false,
+            "html_url": "https://github.com/testorg/existing-repo",
+            "url": "https://api.github.com/repos/testorg/existing-repo",
+            "owner": {
+                "login": "testorg",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/testorg",
+                "html_url": "https://github.com/testorg",
+                "followers_url": "https://api.github.com/users/testorg/followers",
+                "following_url": "https://api.github.com/users/testorg/following{/other_user}",
+                "gists_url": "https://api.github.com/users/testorg/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/testorg/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/testorg/subscriptions",
+                "organizations_url": "https://api.github.com/users/testorg/orgs",
+                "repos_url": "https://api.github.com/users/testorg/repos",
+                "events_url": "https://api.github.com/users/testorg/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/testorg/received_events",
+                "type": "Organization",
+                "site_admin": false,
+                "patch_url": null,
+                "email": null
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Point the handler's GitHub client at the mock server.
+    let state = AppState::default().with_github_api_base_url(mock_server.uri());
+
+    let app = create_router_without_auth(state).layer(middleware::from_fn(
+        |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+            req.extensions_mut()
+                .insert(crate::middleware::AuthContext::new("x".to_string()));
+            next.run(req).await
+        },
+    ));
+
+    let request_body = json!({
+        "organization": "testorg",
+        "name": "existing-repo"
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/repositories/validate-name")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Format is valid, but the name is taken — available must be false.
+    assert_eq!(response_json["valid"], true, "name format is valid");
+    assert_eq!(
+        response_json["available"], false,
+        "name is already taken; available must be false"
+    );
+    assert!(
+        response_json["messages"].is_array(),
+        "messages should be present when name is taken"
+    );
+}
+
+/// Handler-level test: empty organization field returns valid=false.
+#[tokio::test]
+async fn test_validate_repository_name_empty_org_returns_invalid() {
+    let app = create_router_without_auth(test_app_state()).layer(middleware::from_fn(
+        |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+            req.extensions_mut()
+                .insert(crate::middleware::AuthContext::new(
+                    "test-token-123".to_string(),
+                ));
+            next.run(req).await
+        },
+    ));
+
+    let request_body = json!({
+        "organization": "",
+        "name": "valid-name"
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/repositories/validate-name")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(
+        response_json["valid"], false,
+        "empty org should fail validation"
+    );
+    assert_eq!(response_json["available"], false);
+    let msgs = response_json["messages"]
+        .as_array()
+        .expect("messages should be present");
+    assert!(!msgs.is_empty());
 }
 
 // ============================================================================

--- a/crates/repo_roller_api/src/handlers_tests.rs
+++ b/crates/repo_roller_api/src/handlers_tests.rs
@@ -4,9 +4,12 @@ use super::*;
 use axum::{
     body::Body,
     http::{Request, StatusCode},
+    middleware,
 };
 use serde_json::json;
 use tower::ServiceExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::routes::create_router_without_auth;
 
@@ -56,12 +59,22 @@ async fn test_health_check_timestamp_format() {
 // Repository Management Handler Tests
 // ============================================================================
 
-/// Test validate_repository_name endpoint with valid name
+/// Test validate_repository_name endpoint with valid name.
 ///
-/// Verifies that a valid repository name returns 200 OK with valid=true.
+/// The handler now requires `AuthContext` and calls the GitHub API for
+/// availability. With a fake token the GitHub API returns an error;
+/// the handler degrades gracefully and still responds 200 with valid=true.
 #[tokio::test]
 async fn test_validate_repository_name_valid() {
-    let app = create_router_without_auth(test_app_state());
+    let app = create_router_without_auth(test_app_state()).layer(middleware::from_fn(
+        |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+            req.extensions_mut()
+                .insert(crate::middleware::AuthContext::new(
+                    "test-token-123".to_string(),
+                ));
+            next.run(req).await
+        },
+    ));
 
     let request_body = json!({
         "organization": "testorg",
@@ -86,16 +99,25 @@ async fn test_validate_repository_name_valid() {
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(response_json["valid"], true);
+    // GitHub call fails with fake token — handler degrades: available=true with a warning message.
     assert_eq!(response_json["available"], true);
 }
 
-/// Test validate_repository_name endpoint with invalid name
+/// Test validate_repository_name endpoint with invalid name.
 ///
-/// Verifies that an invalid repository name returns 200 OK with valid=false
-/// and includes validation error details.
+/// Format-invalid names short-circuit before any GitHub API call;
+/// valid=false, available=false is always returned.
 #[tokio::test]
 async fn test_validate_repository_name_invalid() {
-    let app = create_router_without_auth(test_app_state());
+    let app = create_router_without_auth(test_app_state()).layer(middleware::from_fn(
+        |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+            req.extensions_mut()
+                .insert(crate::middleware::AuthContext::new(
+                    "test-token-123".to_string(),
+                ));
+            next.run(req).await
+        },
+    ));
 
     let request_body = json!({
         "organization": "testorg",
@@ -127,13 +149,20 @@ async fn test_validate_repository_name_invalid() {
     let messages = response_json["messages"].as_array().unwrap();
     assert!(!messages.is_empty());
 }
-/// Test validate_repository_name endpoint with empty name
+/// Test validate_repository_name endpoint with empty name.
 ///
-/// Verifies that empty repository name returns 200 OK with valid=false
-/// and appropriate error message.
+/// Empty names fail the format check and short-circuit; no GitHub call is made.
 #[tokio::test]
 async fn test_validate_repository_name_empty() {
-    let app = create_router_without_auth(test_app_state());
+    let app = create_router_without_auth(test_app_state()).layer(middleware::from_fn(
+        |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+            req.extensions_mut()
+                .insert(crate::middleware::AuthContext::new(
+                    "test-token-123".to_string(),
+                ));
+            next.run(req).await
+        },
+    ));
 
     let request_body = json!({
         "organization": "testorg",
@@ -158,6 +187,7 @@ async fn test_validate_repository_name_empty() {
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(response_json["valid"], false);
+    assert_eq!(response_json["available"], false);
     assert!(response_json["messages"].is_array());
     assert!(!response_json["messages"].as_array().unwrap().is_empty());
 }
@@ -473,6 +503,151 @@ async fn test_check_org_naming_rules_reserved_word_returns_message() {
     assert!(
         !messages.is_empty(),
         "Expected error messages when the name is a reserved word"
+    );
+}
+
+// ============================================================================
+// check_repository_availability unit tests
+//
+// These tests call the helper directly with a wiremock-backed GitHubClient
+// so they exercise the availability logic without a live GitHub connection.
+// ============================================================================
+
+/// Repository does not exist (GitHub returns 404) → available=true, no message.
+#[tokio::test]
+async fn test_check_repository_availability_not_found_returns_available() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/testorg/new-repo"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "message": "Not Found",
+            "documentation_url": "https://docs.github.com/rest"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let octocrab = octocrab::Octocrab::builder()
+        .base_uri(mock_server.uri())
+        .unwrap()
+        .personal_token("x".to_string())
+        .build()
+        .unwrap();
+    let client = github_client::GitHubClient::new(octocrab);
+
+    let (available, message) = check_repository_availability(&client, "testorg", "new-repo").await;
+
+    assert!(
+        available,
+        "Repository that does not exist should be available"
+    );
+    assert!(
+        message.is_none(),
+        "No warning message expected when the repository is confirmed free"
+    );
+}
+
+/// Repository already exists (GitHub returns 200) → available=false, message says taken.
+#[tokio::test]
+async fn test_check_repository_availability_exists_returns_not_available() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/testorg/existing-repo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 123,
+            "name": "existing-repo",
+            "full_name": "testorg/existing-repo",
+            "private": false,
+            "html_url": "https://github.com/testorg/existing-repo",
+            "url": "https://api.github.com/repos/testorg/existing-repo",
+            "owner": {
+                "login": "testorg",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/testorg",
+                "html_url": "https://github.com/testorg",
+                "followers_url": "https://api.github.com/users/testorg/followers",
+                "following_url": "https://api.github.com/users/testorg/following{/other_user}",
+                "gists_url": "https://api.github.com/users/testorg/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/testorg/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/testorg/subscriptions",
+                "organizations_url": "https://api.github.com/users/testorg/orgs",
+                "repos_url": "https://api.github.com/users/testorg/repos",
+                "events_url": "https://api.github.com/users/testorg/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/testorg/received_events",
+                "type": "Organization",
+                "site_admin": false,
+                "patch_url": null,
+                "email": null
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let octocrab = octocrab::Octocrab::builder()
+        .base_uri(mock_server.uri())
+        .unwrap()
+        .personal_token("x".to_string())
+        .build()
+        .unwrap();
+    let client = github_client::GitHubClient::new(octocrab);
+
+    let (available, message) =
+        check_repository_availability(&client, "testorg", "existing-repo").await;
+
+    assert!(
+        !available,
+        "Repository that already exists should not be available"
+    );
+    assert!(
+        message.is_some(),
+        "Expected a message explaining the name is taken"
+    );
+    let msg = message.unwrap();
+    assert!(
+        msg.contains("existing-repo"),
+        "Message should mention the repository name; got: {msg}"
+    );
+}
+
+/// GitHub returns a non-404 error → available=true (warn-only), message warns the check failed.
+#[tokio::test]
+async fn test_check_repository_availability_api_error_returns_available_with_warning() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/testorg/some-repo"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "message": "Internal Server Error"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let octocrab = octocrab::Octocrab::builder()
+        .base_uri(mock_server.uri())
+        .unwrap()
+        .personal_token("x".to_string())
+        .build()
+        .unwrap();
+    let client = github_client::GitHubClient::new(octocrab);
+
+    let (available, message) = check_repository_availability(&client, "testorg", "some-repo").await;
+
+    assert!(
+        available,
+        "API errors should not block the user: available must be true"
+    );
+    assert!(
+        message.is_some(),
+        "Expected a warning message when the availability check fails"
+    );
+    let msg = message.unwrap();
+    assert!(
+        msg.to_lowercase().contains("could not verify"),
+        "Warning should mention that availability could not be verified; got: {msg}"
     );
 }
 

--- a/crates/repo_roller_api/src/handlers_tests.rs
+++ b/crates/repo_roller_api/src/handlers_tests.rs
@@ -817,8 +817,6 @@ async fn test_validate_repository_name_empty_org_returns_invalid() {
 /// connection.
 #[tokio::test]
 async fn test_list_organization_teams_route_is_registered() {
-    use axum::middleware;
-
     // Build a router that injects a fake AuthContext so the handler can
     // extract it, then let the GitHub API call fail naturally.
     let app = create_router_without_auth(test_app_state()).layer(middleware::from_fn(

--- a/crates/repo_roller_api/src/main.rs
+++ b/crates/repo_roller_api/src/main.rs
@@ -46,6 +46,11 @@ pub struct AppState {
     /// Cloned (Arc clone, not a new allocation) for each handler invocation so
     /// that metric values accumulate across requests.
     pub event_metrics: std::sync::Arc<repo_roller_core::event_metrics::PrometheusEventMetrics>,
+    /// Optional GitHub API base URL override.
+    ///
+    /// When `None` the default `https://api.github.com` is used. Set this to
+    /// target a GitHub Enterprise instance or (in tests) a wiremock server.
+    pub(crate) github_api_base_url: Option<String>,
 }
 
 impl AppState {
@@ -61,7 +66,17 @@ impl AppState {
             event_metrics: std::sync::Arc::new(
                 repo_roller_core::event_metrics::PrometheusEventMetrics::new(&registry),
             ),
+            github_api_base_url: None,
         }
+    }
+
+    /// Override the GitHub API base URL.
+    ///
+    /// Useful for GitHub Enterprise deployments and for pointing at a mock
+    /// server in integration tests.
+    pub fn with_github_api_base_url(mut self, url: impl Into<String>) -> Self {
+        self.github_api_base_url = Some(url.into());
+        self
     }
 }
 

--- a/crates/repo_roller_core/src/request.rs
+++ b/crates/repo_roller_core/src/request.rs
@@ -45,10 +45,11 @@ mod tests;
 /// ```
 ///
 /// See specs/interfaces/repository-creation-modes.md#contentstrategy-enum
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentStrategy {
     /// Fetch and process files from template repository
+    #[default]
     Template,
 
     /// Create no files (empty repository)
@@ -64,12 +65,6 @@ pub enum ContentStrategy {
         /// Create .gitignore file
         include_gitignore: bool,
     },
-}
-
-impl Default for ContentStrategy {
-    fn default() -> Self {
-        Self::Template
-    }
 }
 
 /// Request for creating a new repository with validated types.


### PR DESCRIPTION
Adds a live GitHub repository existence check to `POST /api/v1/repositories/validate-name` so the frontend can surface name collisions before the user reaches the creation step.

## What Changed

- `validate_repository_name` handler (`crates/repo_roller_api/src/handlers.rs`): auth parameter changed from `Option<Extension<AuthContext>>` to `Extension<AuthContext>` (required); format-invalid names now short-circuit immediately without a GitHub round-trip; a new `check_repository_availability()` helper calls `GitHubClient::get_repository()` and maps the result to `(available: bool, optional_warning_message)`
- The handler returns `available: false` when the repository exists, `available: true` when it does not, and `available: true` with a warning message when the GitHub API call fails (never a 5xx)
- `crates/repo_roller_api/Cargo.toml`: added `octocrab` and `wiremock` as dev-dependencies to support mock-server testing
- Pre-existing clippy warnings fixed opportunistically: `ContentStrategy` in `repo_roller_core` switched to `#[derive(Default)]`; unnecessary `unwrap` removed in `integration_tests`

## Why

The `validate-name` endpoint previously echoed the format-check result as `available`, so the frontend always showed "Available" for any correctly-formatted name. Users would only discover a name collision when the creation call failed — after filling in all wizard fields. This change allows the frontend to warn the user at the name-entry step (UX-ASSERT-028: check failure is warn-only, not a hard block).

## How

`check_repository_availability()` calls the existing `GitHubClient::get_repository(org, name)` method. A `NotFound` error means the name is free; an `Ok` response means it is taken; any other error degrades gracefully — the handler returns `available: true` with a human-readable warning so the user can still proceed. The client is constructed from `auth.token` using the same `create_token_client` path already used by `create_repository`.

## Testing Evidence

- **Test Coverage:** 3 new unit tests for `check_repository_availability` (name free, name taken, API error) using a wiremock mock server; 3 existing handler tests updated to inject `AuthContext` after the signature change; total handler test count: 107
- **Test Results:** 107/107 backend tests passing; workspace clippy clean (`-D warnings`); 279/279 frontend Vitest tests unaffected and passing
- **Manual Testing:** Not applicable — all scenarios covered by the wiremock-backed unit tests

## Reviewer Guidance

- `validate_repository_name` no longer accepts unauthenticated requests — the route sits inside `protected_routes` so auth is always present in production, but any test that bypasses auth middleware must now inject an `AuthContext` extension (see the updated test helpers in `handlers_tests.rs`)
- The availability check is warn-only per UX-ASSERT-028: `available: false` does not block form submission on the frontend — no frontend changes are required
- The GitHub API call adds one network round-trip per name-validation request; consider rate-limit implications if the frontend debounces aggressively