### PR TITLE
fix(ci): install mingw-w64 before Windows cross-compile build

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -165,6 +165,11 @@ jobs:
 
           echo "Frontend container image published successfully"
 
+      - name: Install cross-compilation toolchains
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends mingw-w64
+
       - name: Build CLI binaries
         id: build_binaries
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth_handler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "github_client",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "config_manager"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "github_client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2624,7 +2624,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repo_roller_api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "repo_roller_cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "auth_handler",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "repo_roller_core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "auth_handler",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "template_engine"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "test_cleanup"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Fixes the release publish workflow where the Windows CLI binary build failed because the required MinGW-w64 toolchain was not present on the ubuntu-latest runner.

## What Changed
Added an `Install cross-compilation toolchains` step in `.github/workflows/release-publish.yml` that runs `apt-get install mingw-w64` before the `Build CLI binaries` step.

## Why
The `x86_64-pc-windows-gnu` Rust target delegates linking and DLL tool operations to the MinGW-w64 toolchain (`x86_64-w64-mingw32-dlltool`, `x86_64-w64-mingw32-gcc`). These tools are not installed on the `ubuntu-latest` GitHub Actions runner by default, causing the Windows cross-compile to fail with:

    error: error calling dlltool 'x86_64-w64-mingw32-dlltool': No such file or directory (os error 2)


## How
A single `apt-get install -y --no-install-recommends mingw-w64` step is inserted immediately before the binary build step. The `--no-install-recommends` flag keeps the install lean. The existing `rustup target add x86_64-pc-windows-gnu` call in the build step is unchanged.

## Testing Evidence
- **Test Coverage:** No application code changed; no new tests required.
- **Test Results:** Pre-commit hooks (format, clippy) passed locally.
- **Manual Testing:** Fix targets the CI environment; the failure was reproduced from the workflow run logs after the previous release PR was merged.

## Reviewer Guidance
- Confirm `mingw-w64` is the correct package name for the `ubuntu-latest` apt registry (it provides `x86_64-w64-mingw32-dlltool` and friends).
- No breaking changes; only adds a dependency install step to the release workflow.


