### PR TITLE
fix(release): set version_prefix to v to match existing git tags

### DIFF
--- a/.release-regent.toml
+++ b/.release-regent.toml
@@ -16,7 +16,7 @@
 
 [core]
 # Prefix prepended to version numbers in tags and PR titles.
-version_prefix = ""
+version_prefix = "v"
 
 [core.branches]
 # The default (main) branch of the repository.


### PR DESCRIPTION
## Summary

Release-regent was failing silently on every PR event for this repo with a permanent 404 error.

## Root Cause

The .release-regent.toml had version_prefix = empty string, but all git tags use the v prefix (e.g. v0.8.2).

Release-regent was:
1. Calling list_tags - getting v0.8.2
2. Stripping the prefix to get version 0.8.2
3. Calling get_commits_between with base=0.8.2 - GitHub 404 (tag 0.8.2 does not exist, only v0.8.2 does)
4. Rejecting the event as permanent - no release PR created or updated

This was confirmed from release-regent logs showing repeated failures for every repo_roller event.

## Fix

Set version_prefix = v so release-regent constructs the correct ref v0.8.2 when querying the GitHub compare API.