### PR TITLE
chore: Add the vscode config to set the window title

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "window.title": "repo-roller - ${activeRepositoryBranchName}${separator}${activeEditorShort}${dirty}"
+}


### PR DESCRIPTION
So that it works in worktrees as well