### PR TITLE
fix(ci): fix release workflow for 0.9.0 tag failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
               with:
                   subject-path: ${{ env.ASSET_PATH }}
                   predicate-type: https://spdx.dev/Document
-                  predicate: ${{ env.SBOM_PATH }}
+                  predicate-path: ${{ env.SBOM_PATH }}
 
     # ─────────────────────────────────────────────────────────────────────────
     # API Docker image
@@ -161,7 +161,7 @@ jobs:
 
             - name: Extract Docker metadata
               id: meta
-              uses: docker/metadata-action@902fa8ec7d6ecbea8a986b5e040ecfe2aa9c17e1 # v5
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
               with:
                   images: ghcr.io/${{ github.repository }}/api
                   tags: |
@@ -215,7 +215,7 @@ jobs:
 
             - name: Extract Docker metadata
               id: meta
-              uses: docker/metadata-action@902fa8ec7d6ecbea8a986b5e040ecfe2aa9c17e1 # v5
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
               with:
                   images: ghcr.io/${{ github.repository }}/frontend
                   tags: |


### PR DESCRIPTION
## Problem

The release workflow failed on every job when triggered by the `0.9.0` tag.

### CLI build jobs

All five CLI targets failed at the **"Attest SBOM for CLI binary"** step with:

```
Error: SyntaxError: Unexpected token 'r', "repo_rolle"... is not valid JSON
```

The `actions/attest` action's `predicate` field expects inline JSON content, but `${{ env.SBOM_PATH }}` is a file path string (e.g. `repo_roller_cli-0.9.0-x86_64-unknown-linux-gnu.sbom.spdx.json`). The correct parameter for a file path is `predicate-path`.

### Docker image jobs (API and frontend)

Both Docker jobs failed at the **"Extract Docker metadata"** step with:

```
Error: Unable to resolve action `docker/metadata-action@902fa8ec7d6ecbea8a986b5e040ecfe2aa9c17e1`
```

The pinned commit SHA `902fa8ec7d6ecbea8a986b5e040ecfe2aa9c17e1` does not exist in the `docker/metadata-action` repository.

## Fix

- **CLI attest SBOM**: changed `predicate:` → `predicate-path:` so the file path is passed correctly.
- **Docker metadata action**: updated the SHA to `c299e40c65443455700f0fdfc63efafe5b349051`, the actual HEAD commit of the `v5` tag.