### PR TITLE
fix: resolve Docker image build failures for API and frontend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
@@ -202,6 +205,9 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,5 +49,13 @@
   },
   "dependencies": {
     "smol-toml": "^1.7.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": ">=5.0.6",
+      "cookie": ">=0.7.0 <2",
+      "js-yaml": ">=4.2.0",
+      "ws": ">=8.20.1"
+    }
   }
 }


### PR DESCRIPTION
## Problem

Two separate failures were causing the Docker image build jobs in the release workflow to fail.

### Frontend — `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`

`pnpm-lock.yaml` contained an `overrides` block for transitive security patches (`brace-expansion`, `cookie`, `js-yaml`, `ws`) that was not reflected in `package.json`. With `pnpm install --frozen-lockfile` the mismatch is a hard error.

**Fix:** add the matching `pnpm.overrides` field to `frontend/package.json`.

### API & Frontend — `Invalid ELF image for this architecture` (arm64)

Both Docker image jobs specified `platforms: linux/amd64,linux/arm64` but only set up Docker Buildx, not QEMU. Without `docker/setup-qemu-action` registering the arm64 binfmt handler, the cross-platform emulated build fails immediately with `.buildkit_qemu_emulator: /bin/sh: Invalid ELF image for this architecture`.

**Fix:** add a `docker/setup-qemu-action` step before `docker/setup-buildx-action` in both `build-api-image` and `build-frontend-image` jobs.