### PR TITLE
fix: include pnpm-workspace.yaml in Docker builder COPY

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 # Copy only the files needed to install dependencies so that this layer is
 # cached independently of source changes. .npmrc must be included here because
 # pnpm reads it during install (e.g. public-hoist-pattern settings).
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 # approvedBuilds in package.json restricts postinstall scripts to esbuild only.
 # Do NOT add --ignore-scripts here — it overrides approvedBuilds and prevents


### PR DESCRIPTION
## Problem

The frontend Docker build was failing with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on `pnpm install --frozen-lockfile`.

Root cause: pnpm 11 no longer reads the `pnpm` field in `package.json` (it warns: 'The pnpm field in package.json is no longer read by pnpm'). Overrides and other workspace settings must now come from `pnpm-workspace.yaml`. The lockfile was generated with those overrides, but the Docker builder stage's COPY instruction omitted `pnpm-workspace.yaml`, so pnpm found overrides in the lockfile but none in the current config, causing a mismatch.

## Fix

Add `pnpm-workspace.yaml` to the COPY instruction in `frontend/Dockerfile` so the overrides are available when `pnpm install --frozen-lockfile` runs.